### PR TITLE
feat: het indel product calling — ref-length FASTA + dual-track products

### DIFF
--- a/bin/findValues.pl
+++ b/bin/findValues.pl
@@ -1,34 +1,55 @@
 #!/usr/bin/perl
 
 use strict;
+use warnings;
 use Getopt::Long;
 
-# Creating Variable
-my ($vcfFile,$outputFile,$sample,$refPos,$shift_count,$refAllele,$altAllele, $refLen, $altLen);
+my ($vcfFile, $outputFile, $sample);
 
-# Creating Arguments
-&GetOptions("vcfFile|i=s" => \$vcfFile,
-            "outputFile|o=s" => \$outputFile,
-	    "sample|s=s" => \$sample,
-           );
+&GetOptions(
+    "vcfFile|i=s"    => \$vcfFile,
+    "outputFile|o=s" => \$outputFile,
+    "sample|s=s"     => \$sample,
+);
 
-# Opening outputFile
-open(O,">$outputFile");
+die "Usage: findValues.pl -i <vcf> -s <sample> -o <output>\n"
+    unless defined $vcfFile && defined $outputFile && defined $sample;
 
-# Starting output fasta file with defline. Retrieving total length of sequence.
-open(I,"zcat $vcfFile |") || die "Unable to open $vcfFile";
+my $cmd = ($vcfFile =~ /\.gz$/) ? "zcat \Q$vcfFile\E" : "cat \Q$vcfFile\E";
+open(my $OUT, '>', $outputFile) or die "Cannot open $outputFile: $!";
+open(my $IN, "$cmd |") or die "Cannot open $vcfFile: $!";
 
-while(<I>){
-    if (/^(.+)\t(\d+)\t\.\t(\w+)\t(\w+)/) {
-        $refPos = $2;
-	$refAllele = $3;
-	$altAllele = $4;
-	$refLen = length($refAllele);
-	$altLen = length($altAllele);
-	$shift_count = $altLen - $refLen;
-	print O "$sample\t$1\t$2\t$shift_count\n";
+while (<$IN>) {
+    next if /^#/;
+    chomp;
+    my @f = split(/\t/, $_);
+    next unless @f >= 10;
+
+    my $seqId     = $f[0];
+    my $pos       = $f[1];
+    my $refAllele = $f[3];
+    my $altAllele = $f[4];
+    my $refLen    = length($refAllele);
+    my $altLen    = length($altAllele);
+    next if $refLen == $altLen;
+
+    my $shift = $altLen - $refLen;
+
+    my @fmt_keys = split(/:/, $f[8]);
+    my @fmt_vals = split(/:/, $f[9]);
+    my %fmt;
+    @fmt{@fmt_keys} = @fmt_vals;
+
+    my $gt = $fmt{GT} // '.';
+    my $zygosity;
+    if ($gt =~ m|^(\d+)[/\|](\d+)|) {
+        $zygosity = ($1 == $2) ? 'hom' : 'het';
+    } else {
+        $zygosity = 'hom';
     }
+
+    print $OUT join("\t", $sample, $seqId, $pos, $shift, $zygosity, $refAllele, $altAllele), "\n";
 }
 
-close I;
-close O;
+close $IN;
+close $OUT;

--- a/bin/makeCodingData.jl
+++ b/bin/makeCodingData.jl
@@ -78,54 +78,26 @@ end
 # ---------------------------------------------------------------------------
 
 """
-    fasta_offset(indel_db, strain, seq_id, before_pos) -> Int
-
-Return the cumulative indel shift for `strain` on `seq_id` at all positions
-strictly less than `before_pos`. Used to convert a reference genomic coordinate
-to the corresponding position in a consensus FASTA that embeds genomic indels.
-"""
-function fasta_offset(indel_db::SQLite.DB, strain::String, seq_id::String, before_pos::Int)
-    row = first(execute(indel_db,
-        "SELECT COALESCE(SUM(shift), 0) FROM genomic_indels
-         WHERE strain = ? AND sequence_id = ? AND position < ?",
-        [strain, seq_id, before_pos]))
-    row[1]
-end
-
-"""
-    extract_cds_sequence(genome_seqs, exon_list, strain, indel_db) -> String
+    extract_cds_sequence(genome_seqs, exon_list) -> String
 
 Splice and return the CDS sequence for a transcript from genome sequences.
 `exon_list` must be in 5'→3' order (as returned by parse_gtf).
 Reverse-complements minus-strand transcripts using IUPAC-aware complement.
 Returns "" if any exon's seq_id is missing from genome_seqs.
-
-For non-reference strains, pass `strain` and `indel_db` so that exon slice
-coordinates are adjusted for upstream genomic indels embedded in the consensus
-FASTA.
 """
-function extract_cds_sequence(genome_seqs::Dict{String,String}, exon_list::Vector{CdsExon},
-                               strain::String="reference",
-                               indel_db::Union{SQLite.DB,Nothing}=nothing)
+function extract_cds_sequence(genome_seqs::Dict{String,String}, exon_list::Vector{CdsExon})
     isempty(exon_list) && return ""
     parts = String[]
     for e in exon_list
         seq = get(genome_seqs, e.seq_id, nothing)
         seq === nothing && return ""
-        if indel_db !== nothing
-            fstart = e.start + fasta_offset(indel_db, strain, e.seq_id, e.start)
-            fstop  = e.stop  + fasta_offset(indel_db, strain, e.seq_id, e.stop + 1)
-        else
-            fstart, fstop = e.start, e.stop
-        end
-        push!(parts, seq[fstart:fstop])
+        push!(parts, seq[e.start:e.stop])
     end
     if exon_list[1].strand != '-'
-        cds = join(parts)
+        join(parts)
     else
-        cds = join(reverse_complement(p) for p in parts)
+        join(reverse_complement(p) for p in parts)
     end
-    cds
 end
 
 # ---------------------------------------------------------------------------
@@ -133,14 +105,14 @@ end
 # ---------------------------------------------------------------------------
 
 """
-    project_indels_to_cds(db, strain, exon_list) -> Vector{Tuple{Int,Int}}
+    project_indels_to_cds(db, strain, exon_list) -> Vector{Tuple{Int,Int,String,String,String}}
 
 Query genomic indels for `strain` that fall within the exons of a transcript,
 convert each to a 0-based CDS-space position, and return
-[(cds_position, shift_amount), ...] sorted in 5'→3' order.
+[(cds_position, shift_amount, zygosity, ref_allele, alt_allele), ...] sorted in 5'→3' order.
 """
 function project_indels_to_cds(db::SQLite.DB, strain::String, exon_list::Vector{CdsExon})
-    result = Tuple{Int,Int}[]
+    result = Tuple{Int, Int, String, String, String}[]
     isempty(exon_list) && return result
 
     seq_id     = exon_list[1].seq_id
@@ -148,19 +120,22 @@ function project_indels_to_cds(db::SQLite.DB, strain::String, exon_list::Vector{
 
     for e in exon_list
         rows = execute(db,
-            "SELECT position, shift FROM genomic_indels
+            "SELECT position, shift, zygosity, ref_allele, alt_allele FROM genomic_indels
              WHERE strain = ? AND sequence_id = ? AND position >= ? AND position <= ?
              ORDER BY position",
             [strain, seq_id, e.start, e.stop])
         for row in rows
-            gpos  = row[1]
-            shift = row[2]
+            gpos       = row[1]::Int
+            shift      = row[2]::Int
+            zygosity   = row[3]::String
+            ref_allele = row[4]::String
+            alt_allele = row[5]::String
             cds_pos = if e.strand == '-'
                 cds_offset + (e.stop - gpos)
             else
                 cds_offset + (gpos - e.start)
             end
-            push!(result, (cds_pos, shift))
+            push!(result, (cds_pos, shift, zygosity, ref_allele, alt_allele))
         end
         cds_offset += e.stop - e.start + 1
     end
@@ -197,7 +172,10 @@ function create_indels_db(path::String)
           strain        TEXT    NOT NULL,
           transcript_id TEXT    NOT NULL,
           position      INTEGER NOT NULL,
-          shift_amount  INTEGER NOT NULL
+          shift_amount  INTEGER NOT NULL,
+          zygosity      TEXT    NOT NULL,
+          ref_allele    TEXT    NOT NULL,
+          alt_allele    TEXT    NOT NULL
         )
     """)
     db
@@ -213,15 +191,14 @@ end
 
 function process_strain(strain, genome_seqs, by_transcript, indel_src_db,
                         cds_insert_stmt, indels_insert_stmt)
-    db_for_coords = strain == "reference" ? nothing : indel_src_db
     for (transcript_id, exon_list) in by_transcript
-        seq = extract_cds_sequence(genome_seqs, exon_list, strain, db_for_coords)
+        seq = extract_cds_sequence(genome_seqs, exon_list)
         isempty(seq) && continue
         execute(cds_insert_stmt, [strain, transcript_id, seq])
 
         cds_indels = project_indels_to_cds(indel_src_db, strain, exon_list)
-        for (pos, shift) in cds_indels
-            execute(indels_insert_stmt, [strain, transcript_id, pos, shift])
+        for (pos, shift, zygosity, ref_allele, alt_allele) in cds_indels
+            execute(indels_insert_stmt, [strain, transcript_id, pos, shift, zygosity, ref_allele, alt_allele])
         end
     end
 end
@@ -254,7 +231,7 @@ function main()
     cds_insert_stmt    = SQLite.Stmt(cds_db,
         "INSERT INTO coding_sequences(strain, transcript_id, sequence) VALUES (?, ?, ?)")
     indels_insert_stmt = SQLite.Stmt(indels_db,
-        "INSERT INTO indels(strain, transcript_id, position, shift_amount) VALUES (?, ?, ?, ?)")
+        "INSERT INTO indels(strain, transcript_id, position, shift_amount, zygosity, ref_allele, alt_allele) VALUES (?, ?, ?, ?, ?, ?, ?)")
 
     # Reference strain — sequences from genomeFastaFile, no indels
     println(stderr, "Extracting reference CDS sequences")

--- a/bin/makeConsensusFastaFromGvcf.py
+++ b/bin/makeConsensusFastaFromGvcf.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import argparse
 import subprocess
-from cyvcf2 import VCF
 
 # IUPAC ambiguity codes keyed by frozenset of bases
 IUPAC = {
@@ -38,10 +37,8 @@ def build_consensus(chrom_name, chrom_len, ref_seq, vcf, min_coverage):
 
     REF blocks   → reference bases from ref_seq (or N if dp < min_coverage)
     SNPs         → IUPAC code derived from GT alleles
-    Indels       → homozygous: the called allele sequence (length may differ
-                   from REF, so the output FASTA diverges from the reference);
-                   heterozygous: N × len(REF) since two different-length
-                   alleles cannot be collapsed into one sequence
+    Indels       → reference bases (homozygous and heterozygous); preserves reference length
+                   since all indel information is tracked in the database
     Gaps in VCF  → N (no coverage)
     """
     segments = []
@@ -90,20 +87,26 @@ def build_consensus(chrom_name, chrom_len, ref_seq, vcf, min_coverage):
 
         alleles = list(dict.fromkeys(gt_str.replace('|', '/').split('/')))   # unique, ordered
 
-        if all(len(a) == 1 for a in alleles):
-            # ── SNP (or hom-ref call) ──
-            base = IUPAC.get(frozenset(alleles), 'N')
-            segments.append(base)
-            ref_pos = pos + 1
+        if all(len(a) == len(v.REF) for a in alleles):
+            # ── SNP or substitution (all alleles match REF length) ──
+            if all(len(a) == 1 for a in alleles):
+                # SNP: all alleles are single bases
+                base = IUPAC.get(frozenset(alleles), 'N')
+                segments.append(base)
+                ref_pos = pos + 1
+            else:
+                # Multi-base substitution: treat as homozygous indel (emit ref)
+                segments.append(ref_seq[pos:pos + len(v.REF)])
+                ref_pos = pos + len(v.REF)
 
         elif len(alleles) == 1:
-            # ── Homozygous indel: emit the actual allele sequence ──
-            segments.append(alleles[0])
+            # ── Homozygous indel: emit reference bases (preserve reference length) ──
+            segments.append(ref_seq[pos:pos + len(v.REF)])
             ref_pos = pos + len(v.REF)   # advance past REF span in reference coords
 
         else:
-            # ── Heterozygous indel: two different-length alleles, mask ──
-            segments.append('N' * len(v.REF))
+            # ── Heterozygous indel: emit reference bases (preserve reference length) ──
+            segments.append(ref_seq[pos:pos + len(v.REF)])
             ref_pos = pos + len(v.REF)
 
     # Fill any remaining reference positions that had no coverage
@@ -120,6 +123,8 @@ def write_fasta(out_fh, name, seq, line_len=60):
 
 
 def main():
+    from cyvcf2 import VCF
+
     parser = argparse.ArgumentParser(
         description='Build a consensus FASTA from a g.vcf, applying IUPAC '
                     'codes for SNPs and actual allele sequences for indels.')

--- a/bin/processSequenceVariations.jl
+++ b/bin/processSequenceVariations.jl
@@ -344,6 +344,21 @@ function load_transcript_sequences(db::SQLite.DB, transcript_id::String)
     result
 end
 
+function lookup_cds_indel(db::SQLite.DB, transcript_id::String, strain::String, cds_pos::Int)::Union{Tuple{String,String,String}, Nothing}
+    rows = collect(execute(db,
+        "SELECT zygosity, ref_allele, alt_allele FROM indels
+         WHERE transcript_id = ? AND strain = ? AND position = ? LIMIT 1",
+        [transcript_id, strain, cds_pos]))
+    isempty(rows) ? nothing : (rows[1][1]::String, rows[1][2]::String, rows[1][3]::String)
+end
+
+function apply_indel_to_cds(cds_seq::String, cds_pos::Int,
+                              ref_allele::String, alt_allele::String)::String
+    before = cds_seq[1 : cds_pos - 1]
+    after  = cds_seq[cds_pos + length(ref_allele) : end]
+    before * alt_allele * after
+end
+
 # ---------------------------------------------------------------------------
 # GVCF record structure
 # ---------------------------------------------------------------------------
@@ -394,11 +409,12 @@ mutable struct Variation
     has_nonsynonomous::Int
     cds_number::Int
     matches_reference::Int
+    is_processed_indel::Int
 end
 
 function Variation()
     Variation("", 0, "", "", "", "", "", "", "", "",
-              0, 0, 0, 0, "", String[], "", "", 0, 0, 0)
+              0, 0, 0, 0, "", String[], "", "", 0, 0, 0, 0)
 end
 
 # ---------------------------------------------------------------------------
@@ -996,7 +1012,32 @@ function annotate_variations!(
             if is_fs
                 v.codon   = "."
                 v.product = String[]
+            elseif length(v.base) != length(v.reference)
+                # Indel path
+                cds_indel = lookup_cds_indel(ctx.indel_db, annotation.transcript_id,
+                                              v.strain, annotation.pos_in_cds)
+                if !isnothing(cds_indel)
+                    (zygosity, ref_allele, alt_allele) = cds_indel
+                    alt_seq     = apply_indel_to_cds(strain_seq, annotation.pos_in_cds,
+                                                      ref_allele, alt_allele)
+                    pic         = position_in_codon(annotation.pos_in_cds)
+                    codon_start = annotation.pos_in_cds - pic
+                    alt_product = codon_start + 3 <= length(alt_seq) ?
+                                  translate_codon(alt_seq[codon_start+1 : codon_start+3]) : "X"
+                    v.codon = "."
+                    if zygosity == "hom"
+                        v.product = [alt_product]
+                    else  # het
+                        ref_product = translate_codon(extract_codon(strain_seq, annotation.pos_in_cds))
+                        v.product   = unique([ref_product, alt_product])
+                    end
+                    v.is_processed_indel = 1
+                else
+                    v.codon   = "."
+                    v.product = String[]
+                end
             else
+                # SNP path
                 strain_codon = extract_codon(strain_seq, annotation.pos_in_cds)
                 v.codon   = strain_codon
                 expanded  = expand_codon(strain_codon)
@@ -1055,7 +1096,8 @@ function build_reference_variation(
         annotation.ref_codon,
         adjacent_snp_causes_product_difference,
         annotation.cds_number,
-        1
+        1,
+        0   # is_processed_indel
     )
 end
 
@@ -1175,21 +1217,36 @@ function write_allele_and_product_files(
     end
 
     for v in variations
-        isempty(v.codon) && continue
-        expanded_codons = expand_codon(v.codon)
-        for ec in expanded_codons
-            product = translate_codon(ec)
-            count   = get(all_product_counts, product, 0)
-            write(product_fh, join([
-                ec,
-                string(annotation.pos_in_codon_val),
-                annotation.transcript_id,
-                string(count),
-                product,
-                string(annotation.pos_in_cds),
-                string(annotation.pos_in_codon_val),
-                string(v.downstream_of_frameshift)
-            ], "\t"), "\n")
+        if v.is_processed_indel == 1 && !isempty(v.product)
+            for product in unique(v.product)
+                count = get(all_product_counts, product, 0)
+                write(product_fh, join([
+                    ".",
+                    string(annotation.pos_in_codon_val),
+                    annotation.transcript_id,
+                    string(count),
+                    product,
+                    string(annotation.pos_in_cds),
+                    string(annotation.pos_in_codon_val),
+                    string(v.downstream_of_frameshift)
+                ], "\t"), "\n")
+            end
+        elseif !isempty(v.codon)
+            expanded_codons = expand_codon(v.codon)
+            for ec in expanded_codons
+                product = translate_codon(ec)
+                count   = get(all_product_counts, product, 0)
+                write(product_fh, join([
+                    ec,
+                    string(annotation.pos_in_codon_val),
+                    annotation.transcript_id,
+                    string(count),
+                    product,
+                    string(annotation.pos_in_cds),
+                    string(annotation.pos_in_codon_val),
+                    string(v.downstream_of_frameshift)
+                ], "\t"), "\n")
+            end
         end
     end
 end

--- a/bin/processSequenceVariations.jl
+++ b/bin/processSequenceVariations.jl
@@ -344,13 +344,6 @@ function load_transcript_sequences(db::SQLite.DB, transcript_id::String)
     result
 end
 
-function get_indel_shift(db::SQLite.DB, transcript_id::String, strain::String, position::Int)
-    row = first(execute(db,
-        "SELECT COALESCE(SUM(shift_amount), 0) FROM indels WHERE transcript_id = ? AND strain = ? AND position < ?",
-        [transcript_id, strain, position]))
-    row[1]::Int
-end
-
 # ---------------------------------------------------------------------------
 # GVCF record structure
 # ---------------------------------------------------------------------------
@@ -1004,9 +997,7 @@ function annotate_variations!(
                 v.codon   = "."
                 v.product = String[]
             else
-                shift        = get_indel_shift(ctx.indel_db, annotation.transcript_id, v.strain, annotation.pos_in_cds)
-                adjusted_pos = annotation.pos_in_cds + shift
-                strain_codon = extract_codon(strain_seq, adjusted_pos)
+                strain_codon = extract_codon(strain_seq, annotation.pos_in_cds)
                 v.codon   = strain_codon
                 expanded  = expand_codon(strain_codon)
                 v.product = [translate_codon(c) for c in expanded]

--- a/docs/superpowers/specs/2026-04-17-het-indel-product-calling-design.md
+++ b/docs/superpowers/specs/2026-04-17-het-indel-product-calling-design.md
@@ -5,97 +5,106 @@
 
 ## Problem
 
-Heterozygous indels cannot be represented in a single-sequence consensus FASTA because the two alleles differ in length. The current pipeline masks het indel positions with `N`, the same character used for zero-coverage positions. This means:
+Heterozygous indels cannot be represented in a single-sequence consensus FASTA because the two alleles differ in length. The current pipeline masks het indel positions with `N`, the same character used for zero-coverage positions. Homozygous indels are emitted as the called ALT allele, causing the consensus FASTA to diverge in length from the reference. This means:
 
-1. Downstream CDS extraction at het indel positions yields `N` bases → unknown amino acids.
-2. Products cannot be called for het indels, even though het SNPs report both products via IUPAC expansion.
-3. No distinction is made between "no coverage" and "covered but heterozygous indel."
+1. Downstream CDS extraction must track coordinate shifts introduced by applied hom indels.
+2. Het indel positions yield `N` → unknown amino acids, so no products are reported.
+3. No products are reported for het indels, even though het SNPs report both products via IUPAC expansion.
 
 ## Goal
 
-Report both REF-allele and ALT-allele products for heterozygous indels, consistent with how het SNPs are handled today.
+Report both REF-allele and ALT-allele products for heterozygous indels, consistent with how het SNPs are handled today. Simplify the coordinate system by keeping the consensus FASTA permanently reference-length.
+
+## Core Principle
+
+The consensus FASTA is a SNP + coverage artifact only. It never encodes indels.
+
+| Position type | FASTA | DB |
+|---|---|---|
+| Low / no coverage | `N` | — |
+| SNP | IUPAC code | — |
+| Hom insertion | ref bases | yes |
+| Hom deletion | ref bases | yes |
+| Het insertion | ref bases | yes |
+| Het deletion | ref bases | yes |
+
+All indel information — zygosity, REF allele, ALT allele — lives exclusively in the `genomic_indels` table. `makeCodingData.jl` applies indels at product-calling time from the DB. The FASTA coordinate system is always reference space; no shifting required.
 
 ## Design
 
 ### Signal layer — `makeConsensusFastaFromGvcf.py`
 
-Change the het indel masking character from `N` to `X`.
+Two changes to `build_consensus`:
 
-- `N` = no coverage (zero depth or below `minCoverage`)
-- `X` = position has coverage but carries a heterozygous indel that cannot be collapsed into a single allele
+1. **Hom indel branch** (currently lines 99–102): replace `segments.append(alleles[0])` with `segments.append(ref_seq[pos:pos + len(v.REF)])`. The REF span is preserved; the FASTA length never diverges from the reference.
 
-`X` is not a nucleotide IUPAC code and not an amino acid IUPAC code (uppercase `X` is "unknown amino acid" in protein FASTA, but this is a nucleotide FASTA). It is unambiguous in this context.
+2. **Het indel branch** (currently lines 104–107): replace `segments.append('N' * len(v.REF))` with `segments.append(ref_seq[pos:pos + len(v.REF)])`. `N` is reserved for low/no coverage only.
 
-**Change:** `bin/makeConsensusFastaFromGvcf.py`, line ~106:
-```python
-# before
-segments.append('N' * len(v.REF))
-# after
-segments.append('X' * len(v.REF))
-```
+### Data layer — `genomic_indels` table
 
-### Data propagation — het indel alleles into the pipeline
+**`findValues.pl`** (via `makeIndelTSV`): extend output to include all indels with a `zygosity` column (`hom` / `het`) and explicit `ref_allele` / `alt_allele` columns.
 
-`makeCodingData.jl` only has the consensus FASTA and the genomic indels DB. To generate the ALT-track CDS sequence, it needs the REF and ALT allele sequences at each het indel position.
-
-**`findValues.pl`** (via `makeIndelTSV`): extend output to include het indels, with a `is_het` flag and explicit `ref` / `alt` allele columns.
-
-**`makeGenomicIndelDb`** (Nextflow process): add a second table:
+**`makeGenomicIndelDb`** (Nextflow process): single table covering both hom and het indels:
 
 ```sql
-CREATE TABLE genomic_het_indels (
+CREATE TABLE genomic_indels (
   strain      TEXT NOT NULL,
   sequence_id TEXT NOT NULL,
   position    INTEGER NOT NULL,
+  zygosity    TEXT NOT NULL,   -- 'hom' or 'het'
   ref_allele  TEXT NOT NULL,
   alt_allele  TEXT NOT NULL
 );
-CREATE INDEX idx_het ON genomic_het_indels(strain, sequence_id, position);
+CREATE INDEX idx_indels ON genomic_indels(strain, sequence_id, position);
 ```
 
-### Dual-track CDS — `makeCodingData.jl`
+### CDS extraction — `makeCodingData.jl`
 
-Extend `coding_sequences` schema with an `allele_track` column:
+This step produces two SQLite DBs: `codingSequences.db` and `codingIndels.db`.
+
+**`codingSequences.db`** — `coding_sequences(strain, transcript_id, sequence)`
+
+Currently, hom indels are embedded in the consensus FASTA so `extract_cds_sequence` must call `fasta_offset` to shift exon slice coordinates before slicing. Under the new architecture the FASTA is always reference-length, so exon coordinates map directly — `fasta_offset` is removed entirely. Sequences stored here are reference-coordinate slices with SNPs applied and ref bases at all indel positions.
+
+**`codingIndels.db`** — `indels(strain, transcript_id, position, shift_amount)`
+
+`project_indels_to_cds` already translates genomic indel positions to CDS-space coordinates. The schema gains three columns so `processSequenceVariations.jl` can apply the indels directly:
 
 ```sql
-CREATE TABLE coding_sequences (
-  strain        TEXT NOT NULL,
-  transcript_id TEXT NOT NULL,
-  allele_track  TEXT NOT NULL DEFAULT 'main',
-  sequence      TEXT NOT NULL,
-  PRIMARY KEY (strain, transcript_id, allele_track)
+CREATE TABLE indels (
+  strain        TEXT    NOT NULL,
+  transcript_id TEXT    NOT NULL,
+  position      INTEGER NOT NULL,
+  shift_amount  INTEGER NOT NULL,
+  zygosity      TEXT    NOT NULL,   -- 'hom' or 'het'
+  ref_allele    TEXT    NOT NULL,
+  alt_allele    TEXT    NOT NULL
 );
 ```
 
-When extracting CDS for a strain:
-
-1. **REF-track (`allele_track = 'main'`):** At `X` positions in the consensus FASTA, substitute the REF allele from the reference genome (no coordinate shift for the het indel). This is the same coordinate space as today.
-2. **ALT-track (`allele_track = 'het_alt'`):** Apply the ALT allele from `genomic_het_indels` at those positions. This sequence may differ in length from the REF-track CDS from the het indel position onward.
-
-Only transcripts that overlap at least one het indel position (i.e., contain an `X` in their CDS slice) generate a `het_alt` row. All others store only `allele_track = 'main'`.
+The coordinate projection logic in `project_indels_to_cds` is otherwise unchanged.
 
 ### Product reporting — `processSequenceVariations.jl`
 
-When the variant stream encounters a het indel position (identified by `X` in the merged VCF or by the het indel tables):
+Reads `codingSequences.db` (reference-space CDS slice) and `codingIndels.db` (CDS-space positions + alleles). When a variant record overlaps an indel position:
 
-1. Load both `main` and `het_alt` CDS sequences for the affected `(strain, transcript_id)`.
-2. Translate each independently (with existing `expand_codon` / `translate_codon` logic).
-3. Emit both products to `product.dat` — same format as het SNP products today.
+- **Hom indel:** apply ALT allele to the CDS sequence; translate; emit one product to `product.dat`.
+- **Het indel:** produce two sequences — one with REF (the slice as-is) and one with ALT applied; translate each independently; emit both products — same format as het SNP products today.
 
-Strains with no het indels in a transcript continue to use the single `main` sequence path unchanged.
+Strains with no indels in a transcript translate the CDS slice directly, unchanged.
 
 ## Affected Files
 
 | File | Change |
 |------|--------|
-| `bin/makeConsensusFastaFromGvcf.py` | `N` → `X` for het indels |
-| `bin/findValues.pl` | Output het indels with ref/alt alleles |
-| `modules/mergeExperiments.nf` (`makeGenomicIndelDb`) | Add `genomic_het_indels` table |
-| `bin/makeCodingData.jl` | Dual-track CDS generation; schema extension |
-| `bin/processSequenceVariations.jl` | Load both tracks; emit both products for het indels |
+| `bin/makeConsensusFastaFromGvcf.py` | Emit ref bases for all indels (hom and het); `N` reserved for low/no coverage only |
+| `bin/findValues.pl` | Output all indels with `zygosity`, `ref_allele`, `alt_allele` columns |
+| `modules/mergeExperiments.nf` (`makeGenomicIndelDb`) | Single `genomic_indels` table replacing prior hom-only approach |
+| `bin/makeCodingData.jl` | Remove `fasta_offset`; reference-coordinate slicing; add `zygosity`/`ref_allele`/`alt_allele` to `codingIndels.db` |
+| `bin/processSequenceVariations.jl` | Load both tracks for het indels; emit both products |
 
 ## Out of Scope
 
 - Changes to the SNP or het SNP handling path (unchanged).
 - Changes to CNV, windowed coverage, or any workflow other than `processSingleExperiment` → `mergeExperiments`.
-- Phasing: if a transcript has multiple het indels, the `het_alt` track applies all ALT alleles simultaneously (not per-permutation). We do not enumerate compound het combinations.
+- Phasing: multiple het indels in one transcript all receive ALT applied simultaneously — no compound het enumeration.

--- a/docs/superpowers/specs/2026-04-17-het-indel-product-calling-design.md
+++ b/docs/superpowers/specs/2026-04-17-het-indel-product-calling-design.md
@@ -1,0 +1,101 @@
+# Het Indel Product Calling — Design Spec
+
+**Date:** 2026-04-17  
+**Status:** Approved
+
+## Problem
+
+Heterozygous indels cannot be represented in a single-sequence consensus FASTA because the two alleles differ in length. The current pipeline masks het indel positions with `N`, the same character used for zero-coverage positions. This means:
+
+1. Downstream CDS extraction at het indel positions yields `N` bases → unknown amino acids.
+2. Products cannot be called for het indels, even though het SNPs report both products via IUPAC expansion.
+3. No distinction is made between "no coverage" and "covered but heterozygous indel."
+
+## Goal
+
+Report both REF-allele and ALT-allele products for heterozygous indels, consistent with how het SNPs are handled today.
+
+## Design
+
+### Signal layer — `makeConsensusFastaFromGvcf.py`
+
+Change the het indel masking character from `N` to `X`.
+
+- `N` = no coverage (zero depth or below `minCoverage`)
+- `X` = position has coverage but carries a heterozygous indel that cannot be collapsed into a single allele
+
+`X` is not a nucleotide IUPAC code and not an amino acid IUPAC code (uppercase `X` is "unknown amino acid" in protein FASTA, but this is a nucleotide FASTA). It is unambiguous in this context.
+
+**Change:** `bin/makeConsensusFastaFromGvcf.py`, line ~106:
+```python
+# before
+segments.append('N' * len(v.REF))
+# after
+segments.append('X' * len(v.REF))
+```
+
+### Data propagation — het indel alleles into the pipeline
+
+`makeCodingData.jl` only has the consensus FASTA and the genomic indels DB. To generate the ALT-track CDS sequence, it needs the REF and ALT allele sequences at each het indel position.
+
+**`findValues.pl`** (via `makeIndelTSV`): extend output to include het indels, with a `is_het` flag and explicit `ref` / `alt` allele columns.
+
+**`makeGenomicIndelDb`** (Nextflow process): add a second table:
+
+```sql
+CREATE TABLE genomic_het_indels (
+  strain      TEXT NOT NULL,
+  sequence_id TEXT NOT NULL,
+  position    INTEGER NOT NULL,
+  ref_allele  TEXT NOT NULL,
+  alt_allele  TEXT NOT NULL
+);
+CREATE INDEX idx_het ON genomic_het_indels(strain, sequence_id, position);
+```
+
+### Dual-track CDS — `makeCodingData.jl`
+
+Extend `coding_sequences` schema with an `allele_track` column:
+
+```sql
+CREATE TABLE coding_sequences (
+  strain        TEXT NOT NULL,
+  transcript_id TEXT NOT NULL,
+  allele_track  TEXT NOT NULL DEFAULT 'main',
+  sequence      TEXT NOT NULL,
+  PRIMARY KEY (strain, transcript_id, allele_track)
+);
+```
+
+When extracting CDS for a strain:
+
+1. **REF-track (`allele_track = 'main'`):** At `X` positions in the consensus FASTA, substitute the REF allele from the reference genome (no coordinate shift for the het indel). This is the same coordinate space as today.
+2. **ALT-track (`allele_track = 'het_alt'`):** Apply the ALT allele from `genomic_het_indels` at those positions. This sequence may differ in length from the REF-track CDS from the het indel position onward.
+
+Only transcripts that overlap at least one het indel position (i.e., contain an `X` in their CDS slice) generate a `het_alt` row. All others store only `allele_track = 'main'`.
+
+### Product reporting — `processSequenceVariations.jl`
+
+When the variant stream encounters a het indel position (identified by `X` in the merged VCF or by the het indel tables):
+
+1. Load both `main` and `het_alt` CDS sequences for the affected `(strain, transcript_id)`.
+2. Translate each independently (with existing `expand_codon` / `translate_codon` logic).
+3. Emit both products to `product.dat` — same format as het SNP products today.
+
+Strains with no het indels in a transcript continue to use the single `main` sequence path unchanged.
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `bin/makeConsensusFastaFromGvcf.py` | `N` → `X` for het indels |
+| `bin/findValues.pl` | Output het indels with ref/alt alleles |
+| `modules/mergeExperiments.nf` (`makeGenomicIndelDb`) | Add `genomic_het_indels` table |
+| `bin/makeCodingData.jl` | Dual-track CDS generation; schema extension |
+| `bin/processSequenceVariations.jl` | Load both tracks; emit both products for het indels |
+
+## Out of Scope
+
+- Changes to the SNP or het SNP handling path (unchanged).
+- Changes to CNV, windowed coverage, or any workflow other than `processSingleExperiment` → `mergeExperiments`.
+- Phasing: if a transcript has multiple het indels, the `het_alt` track applies all ALT alleles simultaneously (not per-permutation). We do not enumerate compound het combinations.

--- a/modules/mergeExperiments.nf
+++ b/modules/mergeExperiments.nf
@@ -125,7 +125,10 @@ CREATE TABLE genomic_indels (
   strain      TEXT    NOT NULL,
   sequence_id TEXT    NOT NULL,
   position    INTEGER NOT NULL,
-  shift       INTEGER NOT NULL
+  shift       INTEGER NOT NULL,
+  zygosity    TEXT    NOT NULL,
+  ref_allele  TEXT    NOT NULL,
+  alt_allele  TEXT    NOT NULL
 );
 .separator "\\t"
 .import indels.tsv genomic_indels

--- a/testing/t/findValues.t
+++ b/testing/t/findValues.t
@@ -1,0 +1,45 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test2::V0;
+use File::Temp qw(tempfile);
+
+my $vcf_content = <<'VCF';
+##fileformat=VCFv4.2
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample1
+chr1	100	.	ATGC	A	50	PASS	DP=30	GT:DP	1/1:30
+chr1	200	.	A	ATGC	50	PASS	DP=25	GT:DP	0/1:25
+chr1	300	.	A	G	50	PASS	DP=20	GT:DP	1/1:20
+VCF
+
+my ($in_fh, $in_file)   = tempfile(SUFFIX => '.vcf');
+my ($out_fh, $out_file) = tempfile(SUFFIX => '.tsv');
+print $in_fh $vcf_content;
+close $in_fh;
+close $out_fh;
+
+system("perl bin/findValues.pl -i $in_file -s strainA -o $out_file") == 0
+    or die "findValues.pl failed";
+
+open(my $fh, '<', $out_file) or die "Cannot open $out_file";
+my @lines = grep { chomp; length($_) } <$fh>;
+close $fh;
+
+is(scalar @lines, 2, 'two indels emitted (SNP skipped)');
+
+my @f1 = split(/\t/, $lines[0]);
+is($f1[0], 'strainA', 'sample name');
+is($f1[1], 'chr1',    'seq_id');
+is($f1[2], '100',     'position');
+is($f1[3], '-3',      'shift (ATGC->A = -3)');
+is($f1[4], 'hom',     'zygosity hom (GT=1/1)');
+is($f1[5], 'ATGC',    'ref_allele');
+is($f1[6], 'A',       'alt_allele');
+
+my @f2 = split(/\t/, $lines[1]);
+is($f2[3], '3',    'shift (A->ATGC = +3)');
+is($f2[4], 'het',  'zygosity het (GT=0/1)');
+is($f2[5], 'A',    'ref_allele');
+is($f2[6], 'ATGC', 'alt_allele');
+
+done_testing();

--- a/testing/t/makeCodingData.jl
+++ b/testing/t/makeCodingData.jl
@@ -17,9 +17,11 @@ include(joinpath(@__DIR__, "../../bin/makeCodingData.jl"))
 function make_genomic_indel_db(rows::Vector)
     db = SQLite.DB()
     execute(db, """CREATE TABLE genomic_indels (
-        strain TEXT, sequence_id TEXT, position INTEGER, shift INTEGER)""")
-    for (strain, seq_id, pos, shift) in rows
-        execute(db, "INSERT INTO genomic_indels VALUES (?,?,?,?)", [strain, seq_id, pos, shift])
+        strain TEXT, sequence_id TEXT, position INTEGER, shift INTEGER,
+        zygosity TEXT, ref_allele TEXT, alt_allele TEXT)""")
+    for (strain, seq_id, pos, shift, zygosity, ref_allele, alt_allele) in rows
+        execute(db, "INSERT INTO genomic_indels VALUES (?,?,?,?,?,?,?)",
+                [strain, seq_id, pos, shift, zygosity, ref_allele, alt_allele])
     end
     db
 end
@@ -139,85 +141,59 @@ end
     @test extract_cds_sequence(genome, [exon]) == "NRY"
 end
 
-@testset "extract_cds_sequence plus strand with upstream deletion in FASTA" begin
-    # Reference exon: chr1 6-8 = "TGC" in the reference
-    # Strain has a -2 deletion at position 3 (upstream of exon)
-    # So in the strain FASTA the exon is shifted left by 2: positions 4-6 = "TGC"
-    # FASTA: "AATGCCC..." (2 bases removed at pos 3 → AAATGCCCCC becomes AATGCCCCC)
-    ref_genome   = Dict("chr1" => "AAAAATGCCCCC")  # ref: exon 6-8 = "TGC"
-    strain_fasta = Dict("chr1" => "AAATGCCCCC")    # 2 bases deleted before pos 6
-    exon = CdsExon("chr1", 6, 8, '+', "T1", 1)
-    db = make_genomic_indel_db([("strainA", "chr1", 3, -2)])
-    @test extract_cds_sequence(ref_genome,   [exon])                        == "TGC"
-    @test extract_cds_sequence(strain_fasta, [exon], "strainA", db)         == "TGC"
-end
-
-@testset "extract_cds_sequence plus strand with upstream insertion in FASTA" begin
-    # Reference exon: chr1 4-6 = "CAT"
-    # Strain has a +3 insertion at position 1 (upstream)
-    # FASTA is shifted right by 3: exon is at positions 7-9 in FASTA
-    ref_genome   = Dict("chr1" => "AAACATGG")
-    strain_fasta = Dict("chr1" => "AAATTTCATGG")  # 3 bases inserted at pos 1
-    exon = CdsExon("chr1", 4, 6, '+', "T1", 1)
-    db = make_genomic_indel_db([("strainA", "chr1", 1, 3)])
-    @test extract_cds_sequence(ref_genome,   [exon])                == "CAT"
-    @test extract_cds_sequence(strain_fasta, [exon], "strainA", db) == "CAT"
-end
-
 # ---------------------------------------------------------------------------
 # project_indels_to_cds
 # ---------------------------------------------------------------------------
 
 @testset "project_indels_to_cds plus strand single exon" begin
-    # Exon: chr1 1-100, + strand
-    # Indel at genomic pos 10 → CDS pos 9; at pos 50 → CDS pos 49
     db = make_genomic_indel_db([
-        ("strainA", "chr1", 10, -1),
-        ("strainA", "chr1", 50,  3),
+        ("strainA", "chr1", 10, -1, "hom", "AT",  "A"),
+        ("strainA", "chr1", 50,  3, "het", "A",   "ATTT"),
     ])
     exon = CdsExon("chr1", 1, 100, '+', "T1", 1)
-    @test project_indels_to_cds(db, "strainA", [exon]) == [(9, -1), (49, 3)]
+    result = project_indels_to_cds(db, "strainA", [exon])
+    @test length(result) == 2
+    @test result[1] == (9, -1, "hom", "AT", "A")
+    @test result[2] == (49, 3, "het", "A", "ATTT")
 end
 
 @testset "project_indels_to_cds plus strand two exons" begin
-    # exon1: chr1 1-10 (len 10), exon2: chr1 20-30
-    # Indel at pos 5 → CDS pos 4; at pos 25 → CDS pos 10+(25-20)=15
     db = make_genomic_indel_db([
-        ("strainA", "chr1",  5, -2),
-        ("strainA", "chr1", 25,  1),
+        ("strainA", "chr1",  5, -2, "hom", "ATG", "A"),
+        ("strainA", "chr1", 25,  1, "het", "A",   "AT"),
     ])
     exon1 = CdsExon("chr1",  1, 10, '+', "T1", 1)
     exon2 = CdsExon("chr1", 20, 30, '+', "T1", 2)
-    @test project_indels_to_cds(db, "strainA", [exon1, exon2]) == [(4, -2), (15, 1)]
+    result = project_indels_to_cds(db, "strainA", [exon1, exon2])
+    @test result[1] == (4, -2, "hom", "ATG", "A")
+    @test result[2] == (15, 1, "het", "A", "AT")
 end
 
 @testset "project_indels_to_cds minus strand single exon" begin
-    # Exon: chr1 1-10, - strand (5' end is pos 10)
-    # Indel at pos 8 → CDS pos stop-gpos = 10-8 = 2
-    # Indel at pos 3 → CDS pos 10-3 = 7
-    # Collected in genomic order (3,8), reversed for 5'→3' → [(2,-1),(7,2)]
     db = make_genomic_indel_db([
-        ("strainA", "chr1", 3,  2),
-        ("strainA", "chr1", 8, -1),
+        ("strainA", "chr1", 3,  2, "het", "A",   "ATT"),
+        ("strainA", "chr1", 8, -1, "hom", "AT",  "A"),
     ])
     exon = CdsExon("chr1", 1, 10, '-', "T1", 1)
-    @test project_indels_to_cds(db, "strainA", [exon]) == [(2, -1), (7, 2)]
+    result = project_indels_to_cds(db, "strainA", [exon])
+    @test result[1] == (2, -1, "hom", "AT", "A")
+    @test result[2] == (7,  2, "het", "A", "ATT")
 end
 
 @testset "project_indels_to_cds no indels for strain" begin
-    db = make_genomic_indel_db([("strainA", "chr1", 5, -1)])
+    db = make_genomic_indel_db([("strainA", "chr1", 5, -1, "hom", "AT", "A")])
     exon = CdsExon("chr1", 1, 10, '+', "T1", 1)
     @test isempty(project_indels_to_cds(db, "strainB", [exon]))
 end
 
 @testset "project_indels_to_cds indels outside exon boundaries excluded" begin
     db = make_genomic_indel_db([
-        ("strainA", "chr1",  0, -1),   # before exon
-        ("strainA", "chr1",  5, -1),   # inside
-        ("strainA", "chr1", 11, -1),   # after exon
+        ("strainA", "chr1",  0, -1, "hom", "AT", "A"),
+        ("strainA", "chr1",  5, -1, "hom", "AT", "A"),
+        ("strainA", "chr1", 11, -1, "hom", "AT", "A"),
     ])
     exon = CdsExon("chr1", 1, 10, '+', "T1", 1)
     result = project_indels_to_cds(db, "strainA", [exon])
     @test length(result) == 1
-    @test result[1] == (4, -1)
+    @test result[1][1] == 4
 end

--- a/testing/t/processSequenceVariations.jl
+++ b/testing/t/processSequenceVariations.jl
@@ -1,0 +1,167 @@
+#!/usr/bin/env julia
+
+using Test
+using SQLite
+using SQLite.DBInterface: execute
+
+include(joinpath(@__DIR__, "../../bin/processSequenceVariations.jl"))
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+function make_coding_indels_db(rows::Vector)
+    db = SQLite.DB()
+    execute(db, """CREATE TABLE indels (
+        strain TEXT, transcript_id TEXT, position INTEGER,
+        shift_amount INTEGER, zygosity TEXT, ref_allele TEXT, alt_allele TEXT)""")
+    for (strain, tid, pos, shift, zyg, ref_a, alt_a) in rows
+        execute(db, "INSERT INTO indels VALUES (?,?,?,?,?,?,?)",
+                [strain, tid, pos, shift, zyg, ref_a, alt_a])
+    end
+    db
+end
+
+# ---------------------------------------------------------------------------
+# lookup_cds_indel
+# ---------------------------------------------------------------------------
+
+@testset "lookup_cds_indel returns indel record" begin
+    db = make_coding_indels_db([
+        ("strainA", "T1", 10, -3, "hom", "ATGC", "A"),
+    ])
+    result = lookup_cds_indel(db, "T1", "strainA", 10)
+    @test result !== nothing
+    @test result == ("hom", "ATGC", "A")
+end
+
+@testset "lookup_cds_indel returns nothing when absent" begin
+    db = make_coding_indels_db([
+        ("strainA", "T1", 10, -3, "hom", "ATGC", "A"),
+    ])
+    @test isnothing(lookup_cds_indel(db, "T1", "strainA", 99))
+    @test isnothing(lookup_cds_indel(db, "T1", "strainB", 10))
+end
+
+# ---------------------------------------------------------------------------
+# apply_indel_to_cds
+# ---------------------------------------------------------------------------
+
+@testset "apply_indel_to_cds deletion" begin
+    # CDS = "ATGCCCGGG", deletion at pos 4 (1-based): REF=CCCG, ALT=C
+    cds = "ATGCCCGGG"
+    result = apply_indel_to_cds(cds, 4, "CCCG", "C")
+    @test result == "ATGCGG"
+end
+
+@testset "apply_indel_to_cds insertion" begin
+    # CDS = "ATGCCC", insertion at pos 4: REF=C, ALT=CTTT
+    cds = "ATGCCC"
+    result = apply_indel_to_cds(cds, 4, "C", "CTTT")
+    @test result == "ATGCTTTCC"
+end
+
+@testset "apply_indel_to_cds at start of sequence" begin
+    cds = "ATGCCC"
+    result = apply_indel_to_cds(cds, 1, "ATG", "A")
+    @test result == "ACCC"
+end
+
+@testset "apply_indel_to_cds at end of sequence" begin
+    cds = "ATGCCC"
+    result = apply_indel_to_cds(cds, 4, "CCC", "C")
+    @test result == "ATGC"
+end
+
+# ---------------------------------------------------------------------------
+# Variation struct has is_processed_indel field
+# ---------------------------------------------------------------------------
+
+@testset "Variation default constructor has is_processed_indel=0" begin
+    v = Variation()
+    @test v.is_processed_indel == 0
+end
+
+# ---------------------------------------------------------------------------
+# annotate_variations! indel path (integration)
+# ---------------------------------------------------------------------------
+
+@testset "annotate_variations! hom deletion sets product from ALT-applied CDS" begin
+    # CDS = "ATGCATGAT" (9 bases)
+    # Hom deletion at CDS pos 4: REF="CAT", ALT="C" → CDS becomes "ATGCGAT"
+    # pic = position_in_codon(4) = 1, codon_start = 4-1 = 3 → codon = alt_seq[4:6]
+    # alt_seq = "ATG" + "C" + "GAT" = "ATGCGAT" → alt_seq[4:6] = "CGA" → "R"
+    cds_db = SQLite.DB()
+    execute(cds_db, "CREATE TABLE coding_sequences (strain TEXT, transcript_id TEXT, sequence TEXT)")
+    execute(cds_db, "INSERT INTO coding_sequences VALUES ('strainA','T1','ATGCATGAT')")
+    execute(cds_db, "INSERT INTO coding_sequences VALUES ('reference','T1','ATGCATGAT')")
+
+    indel_db = make_coding_indels_db([
+        ("strainA", "T1", 4, -2, "hom", "CAT", "C"),
+    ])
+
+    tinfo = TranscriptInfo("chr1", 1, CDSInterval[])
+    fs_info = precompute_frameshifts(indel_db, Dict("T1" => tinfo))
+
+    ctx = ProcessingContext(
+        "reference", Set{String}(), CDSInterval[], Dict("T1" => tinfo),
+        cds_db, indel_db, fs_info, ["strainA"]
+    )
+
+    cache = TranscriptSequenceCache(Dict())
+    load_transcript_if_needed!(cache, cds_db, "T1")
+
+    annotation = PositionAnnotation(1, "T1", 1, 4, 1, "CAT", "H")
+
+    v = Variation()
+    v.strain    = "strainA"
+    v.reference = "CAT"
+    v.base      = "C"
+
+    annotate_variations!([v], annotation, ctx, cache)
+
+    @test v.is_processed_indel == 1
+    @test length(v.product) == 1
+    @test v.product[1] == "R"   # translate_codon("CGA") == "R"
+end
+
+@testset "annotate_variations! het insertion sets two products" begin
+    # CDS = "ATGCATGAT"
+    # Het insertion at CDS pos 4: REF="C", ALT="CTT"
+    # REF track: extract_codon("ATGCATGAT", 4) → pic=1, codon_start=3 → "CAT" → "H"
+    # ALT track: apply_indel("ATGCATGAT", 4, "C", "CTT") = "ATG" + "CTT" + "ATGAT" = "ATGCTTATGAT"
+    #   pic=1, codon_start=3 → "CTT" → "L"
+    cds_db = SQLite.DB()
+    execute(cds_db, "CREATE TABLE coding_sequences (strain TEXT, transcript_id TEXT, sequence TEXT)")
+    execute(cds_db, "INSERT INTO coding_sequences VALUES ('strainA','T1','ATGCATGAT')")
+    execute(cds_db, "INSERT INTO coding_sequences VALUES ('reference','T1','ATGCATGAT')")
+
+    indel_db = make_coding_indels_db([
+        ("strainA", "T1", 4, 2, "het", "C", "CTT"),
+    ])
+
+    tinfo = TranscriptInfo("chr1", 1, CDSInterval[])
+    fs_info = precompute_frameshifts(indel_db, Dict("T1" => tinfo))
+
+    ctx = ProcessingContext(
+        "reference", Set{String}(), CDSInterval[], Dict("T1" => tinfo),
+        cds_db, indel_db, fs_info, ["strainA"]
+    )
+
+    cache = TranscriptSequenceCache(Dict())
+    load_transcript_if_needed!(cache, cds_db, "T1")
+
+    annotation = PositionAnnotation(1, "T1", 1, 4, 1, "CAT", "H")
+
+    v = Variation()
+    v.strain    = "strainA"
+    v.reference = "C"
+    v.base      = "CTT"
+
+    annotate_variations!([v], annotation, ctx, cache)
+
+    @test v.is_processed_indel == 1
+    @test length(v.product) == 2
+    @test "H" in v.product
+    @test "L" in v.product   # translate_codon("CTT") == "L"
+end

--- a/testing/t/test_makeConsensusFastaFromGvcf.py
+++ b/testing/t/test_makeConsensusFastaFromGvcf.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+import sys, os, unittest
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../../bin'))
+
+from makeConsensusFastaFromGvcf import build_consensus
+
+class FakeVariant:
+    def __init__(self, pos, ref, alts, dp, gt_bases_val):
+        self.POS = pos
+        self.REF = ref
+        self.ALT = alts
+        self._dp = dp
+        self._gt_bases = gt_bases_val
+        self.FORMAT = ['GT', 'DP']
+
+    def format(self, key):
+        if key == 'DP':
+            return [[self._dp]]
+        return None
+
+    @property
+    def gt_bases(self):
+        return [self._gt_bases]
+
+class FakeVCF:
+    def __init__(self, records):
+        self._records = records
+    def __call__(self, chrom):
+        return iter(self._records)
+
+class TestBuildConsensus(unittest.TestCase):
+
+    def _run(self, chrom_len, ref_seq, records, min_coverage=5):
+        vcf = FakeVCF(records)
+        return build_consensus('chr1', chrom_len, ref_seq, vcf, min_coverage)
+
+    def test_hom_deletion_emits_ref_bases(self):
+        # Hom deletion: REF=ATGC at pos 3 (1-based), ALT=A
+        ref_seq = 'XXATGCXX'
+        rec = FakeVariant(pos=3, ref='ATGC', alts=['A'], dp=20, gt_bases_val='A/A')
+        result = self._run(len(ref_seq), ref_seq, [rec])
+        self.assertEqual(len(result), len(ref_seq), 'output must be reference-length')
+        self.assertEqual(result[2:6], 'ATGC', 'hom deletion emits ref bases')
+
+    def test_het_deletion_emits_ref_bases(self):
+        # Het deletion: REF=ATGC at pos 3 (1-based), ALT=A
+        ref_seq = 'XXATGCXX'
+        rec = FakeVariant(pos=3, ref='ATGC', alts=['A'], dp=20, gt_bases_val='ATGC/A')
+        result = self._run(len(ref_seq), ref_seq, [rec])
+        self.assertEqual(len(result), len(ref_seq), 'output must be reference-length')
+        self.assertEqual(result[2:6], 'ATGC', 'het deletion emits ref bases')
+
+    def test_hom_insertion_emits_ref_bases(self):
+        # Hom insertion: REF=A at pos 3 (1-based), ALT=ATGC
+        ref_seq = 'XXAXX'
+        rec = FakeVariant(pos=3, ref='A', alts=['ATGC'], dp=20, gt_bases_val='ATGC/ATGC')
+        result = self._run(len(ref_seq), ref_seq, [rec])
+        self.assertEqual(len(result), len(ref_seq), 'output must be reference-length')
+        self.assertEqual(result[2], 'A', 'hom insertion emits ref base')
+
+    def test_low_coverage_emits_n(self):
+        ref_seq = 'XXATGCXX'
+        rec = FakeVariant(pos=3, ref='ATGC', alts=['A'], dp=2, gt_bases_val='A/A')
+        result = self._run(len(ref_seq), ref_seq, [rec], min_coverage=5)
+        self.assertEqual(result[2:6], 'NNNN', 'low coverage emits N')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- **Consensus FASTA is now permanently reference-length**: all indel positions (hom and het) emit reference bases. `N` is reserved exclusively for low/no-coverage positions.
- **Single `genomic_indels` table** with `zygosity`, `ref_allele`, `alt_allele` columns replaces the prior hom-only approach. `findValues.pl` now parses GT fields and emits the full 7-column TSV.
- **Het and hom indels now produce amino acid products**: `processSequenceVariations.jl` applies indels to CDS sequences at product-calling time — hom indels emit one product (ALT-applied), het indels emit two products (REF + ALT), consistent with how het SNPs are handled today.

## Files Changed

| File | Change |
|---|---|
| `bin/findValues.pl` | GT parsing → 7-column TSV (zygosity, ref_allele, alt_allele) |
| `modules/mergeExperiments.nf` | `genomic_indels` table extended to 7 columns |
| `bin/makeConsensusFastaFromGvcf.py` | Hom + het indel branches emit ref bases |
| `bin/makeCodingData.jl` | Remove `fasta_offset`; extend `codingIndels.db` schema |
| `bin/processSequenceVariations.jl` | Remove `get_indel_shift`; add `lookup_cds_indel`, `apply_indel_to_cds`; indel product path |
| `testing/t/findValues.t` | New Perl tests |
| `testing/t/test_makeConsensusFastaFromGvcf.py` | New Python tests (4/4 passing on host) |
| `testing/t/makeCodingData.jl` | Updated tests for new schema |
| `testing/t/processSequenceVariations.jl` | New Julia tests (require Docker) |

## Test Plan

- [x] Python tests pass on host: `python3 testing/t/test_makeConsensusFastaFromGvcf.py` (4/4)
- [ ] Julia tests in Docker: `julia testing/t/makeCodingData.jl` and `julia testing/t/processSequenceVariations.jl`
- [ ] Perl tests in Docker: `PERL5LIB=... prove testing/t/findValues.t`
- [ ] End-to-end: run `mergeExperiments` workflow with a sample that has het indels and verify `product.dat` contains both REF and ALT products

🤖 Generated with [Claude Code](https://claude.com/claude-code)