### PR TITLE
feat: wire ploidy into allele-weight calculation and coverage-GT fill

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN wget -q https://github.com/samtools/samtools/releases/download/${SAMTOOLS_VE
 
 ENV BWA_MEM2_VERSION=2.2.1
 RUN wget -q https://github.com/bwa-mem2/bwa-mem2/releases/download/v${BWA_MEM2_VERSION}/bwa-mem2-${BWA_MEM2_VERSION}_x64-linux.tar.bz2 \
-    && tar xjf bwa-mem2-${BWA_MEM2_VERSION}_x64-linux.tar.bz2 \
+    && tar -xjf bwa-mem2-${BWA_MEM2_VERSION}_x64-linux.tar.bz2 \
     && mv bwa-mem2-${BWA_MEM2_VERSION}_x64-linux/bwa-mem2* /usr/local/bin/ \
     && rm -rf bwa-mem2-${BWA_MEM2_VERSION}_x64-linux.tar.bz2 bwa-mem2-${BWA_MEM2_VERSION}_x64-linux
 

--- a/bin/processSequenceVariations.jl
+++ b/bin/processSequenceVariations.jl
@@ -578,6 +578,7 @@ struct ProcessingContext
     fs_info::Dict{String, Dict{String, Tuple{Bool, Int}}}
     all_strains::Vector{String}
     sample_id_map::Dict{String,Int}
+    ploidy::Int
 end
 
 struct OutputWriters
@@ -1085,7 +1086,8 @@ function build_variations_from_record(
     record::VCFRecord,
     all_strains::Vector{String},
     undone_strains::Set{String},
-    chrom_coverage::Dict{String, Vector{Tuple{Int, Int, Float64}}}
+    chrom_coverage::Dict{String, Vector{Tuple{Int, Int, Float64}}},
+    ploidy::Int=1
 )::Vector{Variation}
     variations = Variation[]
 
@@ -1112,7 +1114,7 @@ function build_variations_from_record(
                 v.pvalue             = "."
                 v.snp_source_id      = "NGS_SNP.$(record.chrom).$(record.pos)"
                 v.matches_reference  = 1
-                v.ploidy             = 1   # no GT available; use conservative default
+                v.ploidy             = ploidy
                 push!(variations, v)
             end
             continue
@@ -1204,6 +1206,8 @@ function initialize_processing_context(args, all_strains::Vector{String})
 
     fs_info = precompute_frameshifts(indel_db, transcript_info)
 
+    ploidy = haskey(args, "ploidy") ? parse(Int, args["ploidy"]) : 1
+
     ProcessingContext(
         args["reference_strain"],
         undone_strains,
@@ -1213,7 +1217,8 @@ function initialize_processing_context(args, all_strains::Vector{String})
         indel_db,
         fs_info,
         all_strains,
-        Dict{String,Int}(name => i for (i, name) in enumerate([all_strains..., args["reference_strain"]]))
+        Dict{String,Int}(name => i for (i, name) in enumerate([all_strains..., args["reference_strain"]])),
+        ploidy
     )
 end
 
@@ -1410,6 +1415,28 @@ end
 # Output writing
 # ---------------------------------------------------------------------------
 
+"""
+    compute_allele_weight_map(variations) -> (Dict{String,Int}, Int)
+
+Returns (allele_weight_counts, total_weight).  Het calls contribute weight 1
+to each of ref and alt; hom calls contribute v.ploidy to v.base.
+"""
+function compute_allele_weight_map(variations::Vector{Variation})::Tuple{Dict{String,Int}, Int}
+    weights = Dict{String,Int}()
+    total   = 0
+    for v in variations
+        if !isempty(v.alt_allele)
+            weights[v.reference]  = get(weights, v.reference,  0) + 1
+            weights[v.alt_allele] = get(weights, v.alt_allele, 0) + 1
+            total += 2
+        else
+            weights[v.base] = get(weights, v.base, 0) + v.ploidy
+            total += v.ploidy
+        end
+    end
+    (weights, total)
+end
+
 function write_snp_feature(
     snp_fh::IO,
     variations::Vector{Variation},
@@ -1421,22 +1448,17 @@ function write_snp_feature(
     ref_allele = variations[1].reference
     isempty(ref_allele) && (ref_allele = variations[1].base)
 
-    allele_counts        = Dict{String,Int}()
-    allele_ploidy_counts = Dict{String,Int}()
-    strain_set           = Set{String}()
-    total_ploidy_count   = 0
+    (allele_weights, total_ploidy_count) = compute_allele_weight_map(variations)
 
+    # strain count is per-strain, not ploidy-weighted; compute separately
+    allele_counts = Dict{String,Int}()
+    strain_set    = Set{String}()
     for v in variations
         if !isempty(v.alt_allele)
             allele_counts[v.reference]  = get(allele_counts, v.reference,  0) + 1
             allele_counts[v.alt_allele] = get(allele_counts, v.alt_allele, 0) + 1
-            allele_ploidy_counts[v.reference]  = get(allele_ploidy_counts, v.reference,  0) + 1
-            allele_ploidy_counts[v.alt_allele] = get(allele_ploidy_counts, v.alt_allele, 0) + 1
-            total_ploidy_count += 2
         else
-            allele_counts[v.base]        = get(allele_counts, v.base, 0) + 1
-            allele_ploidy_counts[v.base] = get(allele_ploidy_counts, v.base, 0) + v.ploidy
-            total_ploidy_count += v.ploidy
+            allele_counts[v.base] = get(allele_counts, v.base, 0) + 1
         end
         push!(strain_set, v.strain)
     end
@@ -1453,9 +1475,9 @@ function write_snp_feature(
     minor_allele              = length(sorted_alleles) > 1 ? sorted_alleles[2] : ""
     major_allele_strain_count = allele_counts[major_allele]
     minor_allele_strain_count = length(sorted_alleles) > 1 ? allele_counts[minor_allele] : ""
-    major_allele_frequency    = @sprintf("%.4f", allele_ploidy_counts[major_allele] / total_ploidy_count)
+    major_allele_frequency    = @sprintf("%.4f", allele_weights[major_allele] / total_ploidy_count)
     minor_allele_frequency    = length(sorted_alleles) > 1 ?
-        @sprintf("%.4f", allele_ploidy_counts[minor_allele] / total_ploidy_count) : ""
+        @sprintf("%.4f", allele_weights[minor_allele] / total_ploidy_count) : ""
 
     write(snp_fh, join([
         string(location),
@@ -1482,31 +1504,23 @@ function write_allele_file(
     location::Int,
     sample_id_map::Dict{String,Int}
 )
-    # Expand het calls into ref and alt component entries; hom calls contribute ploidy entries.
-    # Each entry: (strain, coverage, percent, allele_weight)
-    # Het components each count as 1 (one copy of each allele in the het call).
-    # Hom calls count as v.ploidy (all copies carry the same allele).
-    allele_entries = Dict{String, Vector{Tuple{String, Float64, Float64, Int}}}()
+    # allele_entries: allele -> [(strain, coverage, percent)]
+    # allele_weights comes from compute_allele_weight_map for frequency denominator
+    allele_entries = Dict{String, Vector{Tuple{String, Float64, Float64}}}()
 
     for v in variations
         cov = isempty(v.coverage) ? 0.0 : parse(Float64, v.coverage)
         pct = isempty(v.percent)  ? 0.0 : parse(Float64, v.percent)
 
         if !isempty(v.alt_allele)
-            # Het call: emit ref component (100-pct) and alt component (pct) separately
-            push!(get!(allele_entries, v.reference,  []), (v.strain, cov, 100.0 - pct, 1))
-            push!(get!(allele_entries, v.alt_allele, []), (v.strain, cov, pct, 1))
+            push!(get!(allele_entries, v.reference,  []), (v.strain, cov, 100.0 - pct))
+            push!(get!(allele_entries, v.alt_allele, []), (v.strain, cov, pct))
         else
-            push!(get!(allele_entries, v.base, []), (v.strain, cov, pct, v.ploidy))
+            push!(get!(allele_entries, v.base, []), (v.strain, cov, pct))
         end
     end
 
-    total_allele_count = sum(
-        sum(w for (_, _, _, w) in entries)
-        for entries in values(allele_entries);
-        init = 0
-    )
-
+    (allele_weights, total_weight) = compute_allele_weight_map(variations)
     ref_allele = variations[1].reference
 
     for (allele, entries) in allele_entries
@@ -1514,9 +1528,8 @@ function write_allele_file(
         strain_ids       = Set{Int}()
         sum_coverage     = 0.0
         sum_percent      = 0.0
-        allele_count     = 0
 
-        for (strain, cov, pct, weight) in entries
+        for (strain, cov, pct) in entries
             push!(distinct_strains, strain)
             sid = get(sample_id_map, strain, 0)
             if sid > 0
@@ -1526,7 +1539,6 @@ function write_allele_file(
             end
             sum_coverage += cov
             sum_percent  += pct
-            allele_count += weight
         end
 
         n       = length(entries)
@@ -1537,7 +1549,7 @@ function write_allele_file(
             seq_id,
             allele,
             string(length(distinct_strains)),
-            @sprintf("%.4f", allele_count / total_allele_count),
+            @sprintf("%.4f", allele_weights[allele] / total_weight),
             @sprintf("%.2f", sum_coverage / n),
             @sprintf("%.2f", sum_percent  / n),
             ids_str,
@@ -1822,10 +1834,12 @@ that have a missing/dot GT but are covered at this position.
 function fill_missing_coverage_gt(
     record::VCFRecord,
     all_strains::Vector{String},
-    chrom_coverage::Dict{String, Vector{Tuple{Int, Int, Float64}}}
+    chrom_coverage::Dict{String, Vector{Tuple{Int, Int, Float64}}},
+    ploidy::Int=1
 )::Vector{String}
-    gt_idx = findfirst(==("GT"), record.format_keys)
-    dp_idx = findfirst(==("DP"), record.format_keys)
+    gt_idx  = findfirst(==("GT"), record.format_keys)
+    dp_idx  = findfirst(==("DP"), record.format_keys)
+    gt_fill = join(fill("0", ploidy), "/")
     modified = copy(record.sample_data)
     for (i, strain) in enumerate(all_strains)
         i > length(modified) && continue
@@ -1835,7 +1849,7 @@ function fill_missing_coverage_gt(
         (covered, dp) = get_coverage(chrom_coverage, strain, record.pos - 1)
         covered || continue
         fields = fill(".", length(record.format_keys))
-        !isnothing(gt_idx) && (fields[gt_idx] = "0")
+        !isnothing(gt_idx) && (fields[gt_idx] = gt_fill)
         !isnothing(dp_idx) && (fields[dp_idx] = string(round(Int, dp)))
         modified[i] = join(fields, ":")
     end
@@ -1949,7 +1963,7 @@ function handle_variant_record!(
     # Build variations from all records at this position (SNPs + indels combined)
     variations = Variation[]
     for r in records
-        append!(variations, build_variations_from_record(r, all_strains, ctx.undone_strains, chrom_coverage))
+        append!(variations, build_variations_from_record(r, all_strains, ctx.undone_strains, chrom_coverage, ctx.ploidy))
     end
     isempty(variations) && return false
 
@@ -2036,7 +2050,7 @@ function handle_variant_record!(
                          seq_id, location, ctx.all_strains, hsss_prod_code)  # ctx.all_strains is non-ref only; ref handled via ref_vars inside write_hsss_position!
 
     (ref_keys, ref_cann_entries) = build_ref_cann_entries(annotations)
-    modified_sample_data = fill_missing_coverage_gt(record, all_strains, chrom_coverage)
+    modified_sample_data = fill_missing_coverage_gt(record, all_strains, chrom_coverage, ctx.ploidy)
     (alt_cann_entries, alt_strain_to_ca) = assign_cann_keys(alt_strain_entries, all_strains)
 
     # Write one VCF output entry per unique alt (for SnpEff downstream).

--- a/modules/mergeExperiments.nf
+++ b/modules/mergeExperiments.nf
@@ -188,6 +188,7 @@ process processSeqVars {
       --indel_db $indelDb \\
       --gtf_file $gtfFile \\
       --coverage_file $coverageFile \\
+      --ploidy $params.ploidy \\
       --output_vcf output.vcf
 
     mv snpFeature.dat variationFeature.dat

--- a/testing/t/handleVariantRecord.jl
+++ b/testing/t/handleVariantRecord.jl
@@ -711,6 +711,130 @@ end
 # Cache reader compatibility with transcript_product.dat format
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# compute_allele_weight_map — shared helper
+# ---------------------------------------------------------------------------
+
+@testset "compute_allele_weight_map returns correct weights for haploid hom variations" begin
+    v1 = Variation(); v1.base = "A"; v1.reference = "A"; v1.ploidy = 1; v1.alt_allele = ""
+    v2 = Variation(); v2.base = "T"; v2.reference = "A"; v2.ploidy = 1; v2.alt_allele = ""
+    v3 = Variation(); v3.base = "T"; v3.reference = "A"; v3.ploidy = 1; v3.alt_allele = ""
+    (weights, total) = compute_allele_weight_map([v1, v2, v3])
+    @test weights["A"] == 1
+    @test weights["T"] == 2
+    @test total == 3
+end
+
+@testset "compute_allele_weight_map respects ploidy for diploid hom variations" begin
+    v1 = Variation(); v1.base = "A"; v1.reference = "A"; v1.ploidy = 2; v1.alt_allele = ""
+    v2 = Variation(); v2.base = "T"; v2.reference = "A"; v2.ploidy = 2; v2.alt_allele = ""
+    (weights, total) = compute_allele_weight_map([v1, v2])
+    @test weights["A"] == 2
+    @test weights["T"] == 2
+    @test total == 4
+end
+
+@testset "compute_allele_weight_map splits het call: ref and alt each get weight 1" begin
+    v1 = Variation(); v1.base = "A"; v1.reference = "A"; v1.alt_allele = "G"; v1.ploidy = 2
+    (weights, total) = compute_allele_weight_map([v1])
+    @test weights["A"] == 1
+    @test weights["G"] == 1
+    @test total == 2
+end
+
+# ---------------------------------------------------------------------------
+# fill_missing_coverage_gt — ploidy-aware GT string
+# ---------------------------------------------------------------------------
+
+@testset "fill_missing_coverage_gt fills GT=0/0 for diploid covered sample" begin
+    record = make_vcf_record(pos=100, format_keys=["GT","DP"], sample_data=["./.:0"])
+    cov    = make_coverage("s1", 99, 200, 42.0)
+    result = fill_missing_coverage_gt(record, ["s1"], cov, 2)
+    fmt = Dict(zip(record.format_keys, split(result[1], ":")))
+    @test fmt["GT"] == "0/0"
+end
+
+@testset "fill_missing_coverage_gt fills GT=0 for haploid covered sample (ploidy=1)" begin
+    record = make_vcf_record(pos=100, format_keys=["GT","DP"], sample_data=["./.:0"])
+    cov    = make_coverage("s1", 99, 200, 42.0)
+    result = fill_missing_coverage_gt(record, ["s1"], cov, 1)
+    fmt = Dict(zip(record.format_keys, split(result[1], ":")))
+    @test fmt["GT"] == "0"
+end
+
+# ---------------------------------------------------------------------------
+# build_variations_from_record — coverage variation ploidy
+# ---------------------------------------------------------------------------
+
+@testset "build_variations_from_record coverage variation uses ploidy=2 for diploid" begin
+    record = make_vcf_record(pos=100, format_keys=["GT","DP"], sample_data=["./.:0"])
+    cov    = make_coverage("s1", 99, 200, 30.0)
+    vars   = build_variations_from_record(record, ["s1"], Set{String}(), cov, 2)
+    @test length(vars) == 1
+    @test vars[1].ploidy == 2
+    @test vars[1].matches_reference == 1
+end
+
+@testset "build_variations_from_record coverage variation defaults to ploidy=1" begin
+    record = make_vcf_record(pos=100, format_keys=["GT","DP"], sample_data=["./.:0"])
+    cov    = make_coverage("s1", 99, 200, 30.0)
+    vars   = build_variations_from_record(record, ["s1"], Set{String}(), cov)
+    @test length(vars) == 1
+    @test vars[1].ploidy == 1
+end
+
+# ---------------------------------------------------------------------------
+# initialize_processing_context — reads ploidy from args
+# ---------------------------------------------------------------------------
+
+@testset "initialize_processing_context reads ploidy from args" begin
+    tmp_dir = mktempdir()
+    transcript_db_path = joinpath(tmp_dir, "transcripts.db")
+    indel_db_path      = joinpath(tmp_dir, "indels.db")
+    SQLite.DB(transcript_db_path) |> close
+    let db = SQLite.DB(indel_db_path)
+        SQLite.execute(db, "CREATE TABLE indels (strain TEXT, transcript_id TEXT, position INTEGER, shift_amount INTEGER)")
+        close(db)
+    end
+    gtf_path = joinpath(tmp_dir, "empty.gtf")
+    write(gtf_path, "")
+
+    args = Dict(
+        "transcript_db"      => transcript_db_path,
+        "indel_db"           => indel_db_path,
+        "gtf_file"           => gtf_path,
+        "reference_strain"   => "refStrain",
+        "undone_strains_file"=> "",
+        "ploidy"             => "2",
+    )
+    ctx = initialize_processing_context(args, ["strainA"])
+    @test ctx.ploidy == 2
+end
+
+@testset "initialize_processing_context defaults ploidy to 1 when not in args" begin
+    tmp_dir = mktempdir()
+    transcript_db_path = joinpath(tmp_dir, "transcripts.db")
+    indel_db_path      = joinpath(tmp_dir, "indels.db")
+    SQLite.DB(transcript_db_path) |> close
+    let db = SQLite.DB(indel_db_path)
+        SQLite.execute(db, "CREATE TABLE indels (strain TEXT, transcript_id TEXT, position INTEGER, shift_amount INTEGER)")
+        close(db)
+    end
+    gtf_path = joinpath(tmp_dir, "empty.gtf")
+    write(gtf_path, "")
+
+    args = Dict(
+        "transcript_db"      => transcript_db_path,
+        "indel_db"           => indel_db_path,
+        "gtf_file"           => gtf_path,
+        "reference_strain"   => "refStrain",
+        "undone_strains_file"=> "",
+    )
+    ctx = initialize_processing_context(args, ["strainA"])
+    @test ctx.ploidy == 1
+end
+
+# ---------------------------------------------------------------------------
 @testset "parse_cache_tsv_record reads first 4 cols of transcript_product.dat line" begin
     # transcript_product.dat has 12 tab-separated columns:
     # seq_id, location, transcript_id, pos_in_cds, pos_in_protein, codon,


### PR DESCRIPTION
## Summary
- Propagates `ploidy` from args through `ProcessingContext` into `build_variations_from_record` and `fill_missing_coverage_gt`
- Extracts `compute_allele_weight_map` helper so allele frequencies in `variationFeature.dat` and `allele.dat` are ploidy-aware
- Nextflow `processSeqVars` now passes `--ploidy $params.ploidy`

## Test plan
- [ ] `julia testing/t/handleVariantRecord.jl` — new tests for `compute_allele_weight_map`, `fill_missing_coverage_gt`, `build_variations_from_record`, and `initialize_processing_context` ploidy defaulting

🤖 Generated with [Claude Code](https://claude.com/claude-code)