### PR TITLE
Prefix consensus FASTA deflines with sample name

### DIFF
--- a/bin/makeCodingData.jl
+++ b/bin/makeCodingData.jl
@@ -73,6 +73,27 @@ function read_fasta(path::String)
     seqs
 end
 
+"""
+    strip_strain_prefix(seqs, strain) -> Dict{String, String}
+
+Consensus FASTA deflines are written as "<strain>_<sequenceId>" so they are
+globally unique across strains (e.g. for DB loading / display). This strips the
+exact "<strain>_" prefix so the returned dict is keyed by the bare sequenceId,
+matching the sequence_ids used in the GTF for CDS coordinate lookups.
+
+Dropping the strain from the *key* is safe only because the strain identity is
+retained separately by the caller: `main()` derives it from the filename, passes
+it to `process_strain`, and it becomes the `strain` column (part of the primary
+key) in both output SQLite tables. Keys lacking the prefix are left unchanged.
+"""
+function strip_strain_prefix(seqs::Dict{String,String}, strain::String)
+    prefix = strain * "_"
+    Dict(
+        (startswith(k, prefix) ? k[nextind(k, lastindex(prefix)):end] : k) => v
+        for (k, v) in seqs
+    )
+end
+
 # ---------------------------------------------------------------------------
 # CDS sequence extraction
 # ---------------------------------------------------------------------------
@@ -268,7 +289,7 @@ function main()
     for fasta_path in fasta_files
         strain = replace(basename(fasta_path), "_consensus.fa.gz" => "")
         println(stderr, "Processing strain: $strain")
-        strain_seqs = read_fasta(fasta_path)
+        strain_seqs = strip_strain_prefix(read_fasta(fasta_path), strain)
         SQLite.transaction(cds_db) do
             SQLite.transaction(indels_db) do
                 process_strain(strain, strain_seqs, by_transcript, indel_src_db,

--- a/bin/makeConsensusFastaFromVcfAndBed.py
+++ b/bin/makeConsensusFastaFromVcfAndBed.py
@@ -203,6 +203,9 @@ def main():
     parser.add_argument('-b', '--bed',   required=True,
                         help='BED file of covered regions (0-based, half-open)')
     parser.add_argument('-o', '--output', required=True)
+    parser.add_argument('-s', '--sample', required=True,
+                        help='Sample/strain name, prepended to each defline as '
+                             '"<sample>_<sequenceId>"')
     args = parser.parse_args()
 
     chroms = []
@@ -221,7 +224,7 @@ def main():
             ref_seq = get_chrom_seq(args.ref, chrom_name)
             intervals, starts = coverage.get(chrom_name, ([], []))
             seq = build_consensus(chrom_name, chrom_len, ref_seq, vcf, intervals, starts)
-            write_fasta(out, chrom_name, seq)
+            write_fasta(out, f'{args.sample}_{chrom_name}', seq)
 
 
 if __name__ == '__main__':

--- a/modules/snp.nf
+++ b/modules/snp.nf
@@ -187,6 +187,7 @@ process makeConsensusFromVcfAndBed {
       --bed $coverageBed \\
       --ref $genomeReorderedFasta \\
       --fai $genomeReorderedFastaIndex \\
+      --sample $sampleName \\
       --output consensus.fa
     bgzip consensus.fa
     mv consensus.fa.gz ${sampleName}_consensus.fa.gz

--- a/testing/t/makeCodingData.jl
+++ b/testing/t/makeCodingData.jl
@@ -93,6 +93,29 @@ end
 end
 
 # ---------------------------------------------------------------------------
+# strip_strain_prefix
+# ---------------------------------------------------------------------------
+
+@testset "strip_strain_prefix removes exact strain prefix" begin
+    seqs = Dict("strainA_chr1" => "AAAA", "strainA_chr2" => "CCCC")
+    stripped = strip_strain_prefix(seqs, "strainA")
+    @test stripped == Dict("chr1" => "AAAA", "chr2" => "CCCC")
+end
+
+@testset "strip_strain_prefix keeps underscores inside sequenceId" begin
+    # sequence IDs may themselves contain underscores; only the leading
+    # "<strain>_" is removed.
+    seqs = Dict("strainA_contig_00_1" => "GGGG")
+    stripped = strip_strain_prefix(seqs, "strainA")
+    @test stripped == Dict("contig_00_1" => "GGGG")
+end
+
+@testset "strip_strain_prefix leaves non-matching keys unchanged" begin
+    seqs = Dict("chr1" => "TTTT")
+    @test strip_strain_prefix(seqs, "strainA") == Dict("chr1" => "TTTT")
+end
+
+# ---------------------------------------------------------------------------
 # extract_cds_sequence
 # ---------------------------------------------------------------------------
 

--- a/testing/t/test_makeConsensusFastaFromVcfAndBed.py
+++ b/testing/t/test_makeConsensusFastaFromVcfAndBed.py
@@ -231,3 +231,14 @@ def test_write_fasta(tmp_path):
     lines = out.read_text().splitlines()
     assert lines[0] == '>chr1'
     assert ''.join(lines[1:]) == 'ACGT' * 20
+
+
+def test_write_fasta_sample_prefixed_defline(tmp_path):
+    # main() composes the defline as "<sample>_<sequenceId>"; downstream
+    # makeCodingData.jl strips the "<strain>_" prefix to recover the bare
+    # sequenceId. Lock the convention here.
+    out = tmp_path / "out.fa"
+    sample, chrom = 'strainA', 'chr1'
+    with open(out, 'w') as fh:
+        write_fasta(fh, f'{sample}_{chrom}', 'ACGT')
+    assert out.read_text().splitlines()[0] == '>strainA_chr1'


### PR DESCRIPTION
## What

The consensus FASTA emitted by `processSingleExperiment` now writes deflines as `>${sampleName}_${sequenceId}` so they are globally unique across strains (previously the defline was the bare `sequenceId`).

## Changes

| File | Change |
|---|---|
| `bin/makeConsensusFastaFromVcfAndBed.py` | Added required `--sample` arg; `main()` writes deflines as `>{sample}_{chrom}` |
| `modules/snp.nf` | `makeConsensusFromVcfAndBed` passes `--sample $sampleName` |
| `bin/makeCodingData.jl` | New `strip_strain_prefix` helper; each strain's consensus dict is re-keyed to bare `seq_id` after `read_fasta` so GTF coordinate lookups still resolve |
| `testing/t/makeCodingData.jl` | 3 unit tests for `strip_strain_prefix` |
| `testing/t/test_makeConsensusFastaFromVcfAndBed.py` | Test locking the `<sample>_<seqid>` defline convention |

## Downstream impact

`makeCodingData.jl` is the **only active** consumer of the consensus FASTA. It keys sequences by defline and looks them up by the bare GTF `sequence_id`, so the prefix would silently break CDS extraction. `strip_strain_prefix` reverts each strain's dict keys to the bare `sequence_id`. This is safe because the sample identity is retained separately — `main()` derives `strain` from the filename, passes it to `process_strain`, and it becomes the `strain` column (part of the primary key) in `codingSequences.db` / `codingIndels.db`.

Not affected: `snpEff` uses the reference genome, not the consensus. `checkUniqueIds.sh` and the legacy `test.pl` / `processSequenceVariationsNew.pl` are dead code (not wired into any workflow).

## Verification

- **Julia:** all `makeCodingData.jl` tests pass in the `dnaseqanalysis:1.1.0` container, including the 3 new ones.
- **Python:** defline (`>strainA_chr1`) and the new required `--sample` arg verified via standalone run of the module functions.
- **Not run:** full pipeline e2e (`test_coding_sequences_all_transcripts_all_strains` is the guard for the round-trip; needs a real Nextflow run).

## Note

`testing/t/test_makeConsensusFastaFromVcfAndBed.py` is **pre-existing broken** (imports removed `is_covered`, calls `build_consensus` with the old 5-arg signature) — it fails at collection independent of this change. Repairing that suite is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)