### PR TITLE
Remove vestigial undoneStrains strain-skip mechanism

### DIFF
--- a/bin/processSequenceVariations.jl
+++ b/bin/processSequenceVariations.jl
@@ -584,7 +584,6 @@ end
 
 struct ProcessingContext
     reference_strain::String
-    undone_strains::Set{String}
     cds_intervals::Vector{CDSInterval}
     transcript_info::Dict{String,TranscriptInfo}
     transcript_db::SQLite.DB
@@ -1126,7 +1125,7 @@ function compute_percent(fmt::Dict{String,String}, gt::String)::String
 end
 
 """
-    build_variations_from_record(record, all_strains, undone_strains, chrom_coverage)
+    build_variations_from_record(record, all_strains, chrom_coverage)
         -> Vector{Variation}
 
 Builds per-strain Variation records from a VCF variant record.
@@ -1135,7 +1134,6 @@ For missing GTs, synthesizes a reference call if coverage.tsv shows the position
 function build_variations_from_record(
     record::VCFRecord,
     all_strains::Vector{String},
-    undone_strains::Set{String},
     chrom_coverage::Dict{String, Vector{Tuple{Int, Int, Float64}}},
     ploidy::Int=1;
     synthesize_ref::Bool=true,
@@ -1144,7 +1142,6 @@ function build_variations_from_record(
     variations = Variation[]
 
     for (i, strain) in enumerate(all_strains)
-        strain in undone_strains && continue
         i > length(record.sample_data) && continue
 
         fmt = parse_format_field(record.format_keys, record.sample_data[i])
@@ -1244,17 +1241,6 @@ end
     initialize_processing_context(args, all_strains) -> ProcessingContext
 """
 function initialize_processing_context(args, all_strains::Vector{String})
-    undone_strains = Set{String}()
-    undone_strains_file = get(args, "undone_strains_file", "")
-    if !isempty(undone_strains_file) && isfile(undone_strains_file)
-        open(undone_strains_file, "r") do fh
-            for line in eachline(fh)
-                s = strip(line)
-                !isempty(s) && push!(undone_strains, s)
-            end
-        end
-    end
-
     (cds_intervals, transcript_info) = parse_gtf(args["gtf_file"])
 
     transcript_db = SQLite.DB(args["transcript_db"])
@@ -1266,7 +1252,6 @@ function initialize_processing_context(args, all_strains::Vector{String})
 
     ProcessingContext(
         args["reference_strain"],
-        undone_strains,
         cds_intervals,
         transcript_info,
         transcript_db,
@@ -2195,7 +2180,7 @@ function handle_variant_record!(
     per_record = Tuple{VCFRecord, Vector{Variation}}[]
     for r in records
         rv = build_variations_from_record(
-            r, all_strains, ctx.undone_strains, chrom_coverage, ctx.ploidy;
+            r, all_strains, chrom_coverage, ctx.ploidy;
             synthesize_ref = (r === ref_record), no_synth_strains = real_call_strains)
         push!(per_record, (r, rv))
     end

--- a/modules/mergeExperiments.nf
+++ b/modules/mergeExperiments.nf
@@ -160,7 +160,6 @@ process processSeqVars {
   input:
     path vcfFile
     path cacheFile  // previous run's transcript_product.dat (was cache.tsv)
-    path undoneStrainsFile
     val  reference_strain
     path transcriptDb
     path indelDb
@@ -186,7 +185,6 @@ process processSeqVars {
     processSequenceVariations.jl \\
       --vcf_file $vcfFile \\
       --cache_file $cacheFile \\
-      --undone_strains_file $undoneStrainsFile \\
       --reference_strain $reference_strain \\
       --transcript_db $transcriptDb \\
       --indel_db $indelDb \\

--- a/nextflow.config
+++ b/nextflow.config
@@ -61,7 +61,6 @@ profiles {
       outputDir       = "$launchDir/output/"
       genomeFastaFile = "$launchDir/data/genome_haploid/genome.fasta"
       gtfFile         = "$launchDir/data/haploid_paired/Shared/pfal3D7.gtf"
-      undoneStrains   = "$launchDir/data/merge_setup/undoneStrains.txt"
       reference_strain = 'pfal3D7'
     }
 

--- a/testing/t/handleVariantRecord.jl
+++ b/testing/t/handleVariantRecord.jl
@@ -355,7 +355,6 @@ end
         "indel_db"           => indel_db_path,
         "gtf_file"           => gtf_path,
         "reference_strain"   => "refStrain",
-        "undone_strains_file"=> "",
     )
     all_strains = ["strainA", "strainB", "strainC"]
     ctx = initialize_processing_context(args, all_strains)
@@ -1039,7 +1038,7 @@ end
 @testset "build_variations_from_record coverage variation uses ploidy=2 for diploid" begin
     record = make_vcf_record(pos=100, format_keys=["GT","DP"], sample_data=["./.:0"])
     cov    = make_coverage("s1", 99, 200, 30.0)
-    vars   = build_variations_from_record(record, ["s1"], Set{String}(), cov, 2)
+    vars   = build_variations_from_record(record, ["s1"], cov, 2)
     @test length(vars) == 1
     @test vars[1].ploidy == 2
     @test vars[1].matches_reference == 1
@@ -1048,7 +1047,7 @@ end
 @testset "build_variations_from_record coverage variation defaults to ploidy=1" begin
     record = make_vcf_record(pos=100, format_keys=["GT","DP"], sample_data=["./.:0"])
     cov    = make_coverage("s1", 99, 200, 30.0)
-    vars   = build_variations_from_record(record, ["s1"], Set{String}(), cov)
+    vars   = build_variations_from_record(record, ["s1"], cov)
     @test length(vars) == 1
     @test vars[1].ploidy == 1
 end
@@ -1074,7 +1073,6 @@ end
         "indel_db"           => indel_db_path,
         "gtf_file"           => gtf_path,
         "reference_strain"   => "refStrain",
-        "undone_strains_file"=> "",
         "ploidy"             => "2",
     )
     ctx = initialize_processing_context(args, ["strainA"])
@@ -1098,7 +1096,6 @@ end
         "indel_db"           => indel_db_path,
         "gtf_file"           => gtf_path,
         "reference_strain"   => "refStrain",
-        "undone_strains_file"=> "",
     )
     ctx = initialize_processing_context(args, ["strainA"])
     @test ctx.ploidy == 1
@@ -1126,7 +1123,7 @@ end
     indel = make_vcf_record(ref="ATG", alts=["A"],
                             format_keys=["GT","DP"], sample_data=["./.:0"])
     chrom_cov = Dict("S1" => [(1, 1000, 30.0)])
-    vars = build_variations_from_record(indel, ["S1"], Set{String}(), chrom_cov, 1;
+    vars = build_variations_from_record(indel, ["S1"], chrom_cov, 1;
                                         synthesize_ref=false)
     @test isempty(vars)
 end
@@ -1135,7 +1132,7 @@ end
     indel = make_vcf_record(ref="ATG", alts=["A"],
                             format_keys=["GT","DP"], sample_data=["./.:0"])
     chrom_cov = Dict("S1" => [(1, 1000, 30.0)])
-    vars = build_variations_from_record(indel, ["S1"], Set{String}(), chrom_cov, 1;
+    vars = build_variations_from_record(indel, ["S1"], chrom_cov, 1;
                                         synthesize_ref=true)
     @test length(vars) == 1
     @test vars[1].matches_reference == 1
@@ -1184,7 +1181,6 @@ function make_intergenic_ctx(all_strains::Vector{String}; reference_strain="ref"
         "indel_db"            => indel_db_path,
         "gtf_file"            => gtf_path,
         "reference_strain"    => reference_strain,
-        "undone_strains_file" => "",
         "ploidy"              => string(ploidy),
     )
     initialize_processing_context(args, all_strains)
@@ -1397,7 +1393,7 @@ end
     rec = make_vcf_record(pos=8962, ref="T", alts=["TA"],
                           format_keys=["GT","AO","RO"], sample_data=["1/.:7:0"])
     cov = make_coverage("s1", 8961, 200, 12.0)
-    vars = build_variations_from_record(rec, ["s1"], Set{String}(), cov, 2)
+    vars = build_variations_from_record(rec, ["s1"], cov, 2)
     @test length(vars) == 1
     @test vars[1].allele_slots == ["TA"]
     @test vars[1].ploidy == 2

--- a/workflows/mergeExperiments.nf
+++ b/workflows/mergeExperiments.nf
@@ -37,7 +37,6 @@ workflow me {
     processSeqVarsResults = processSeqVars(
       mergedVcf,
       params.cacheFile,
-      params.undoneStrains,
       params.reference_strain,
       codingData.codingSequencesDb,
       codingData.codingIndelsDb,


### PR DESCRIPTION
## What

Rips out the `undoneStrains` file and its `--undone_strains_file` flag end to end.

## Why

`undoneStrains` and `cacheFile` were a *pair* in the legacy incremental-load design: a per-strain product-call cache held results for "done" strains, and `undoneStrains` marked the ones still needing computation so a re-run only recomputed the undone set. **That per-strain cache is gone.** Every strain in the merged VCF is now processed fresh each run, and `cache_file` is only a position→transcript index for skipping GTF re-parsing. "Undone" no longer has a partner to be undone relative to.

Worse than merely dead: its one remaining effect was to *silently drop* listed strains from variation building while still emitting them in `sample.dat` and the `hsss_readFreq*` headers (both built from the unfiltered VCF-header strain list) — an inconsistent partial exclusion with no error surface.

## Changes

| File | Change |
|---|---|
| `bin/processSequenceVariations.jl` | Dropped the `undone_strains` field from `ProcessingContext`, the file loader in `initialize_processing_context`, the `build_variations_from_record` param + skip line, and the call-site arg |
| `modules/mergeExperiments.nf` | Removed the `undoneStrainsFile` process input and `--undone_strains_file` flag |
| `workflows/mergeExperiments.nf` | Removed `params.undoneStrains` from the `processSeqVars` call |
| `nextflow.config` | Deleted the `undoneStrains` param |
| `testing/t/handleVariantRecord.jl` | Dropped the `Set{String}()` arg from 5 direct calls and 4 dead `undone_strains_file` args-dict entries |

Historical `docs/` plans/specs left untouched — they're dated records, not live config.

## Testing

`julia testing/t/handleVariantRecord.jl` in `veupathdb/dnaseqanalysis:latest` → exit 0, all suites green. Dockerfile untouched, so `:latest` remains valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)