### PR TITLE
Benchmark + fix SQL hotspots in mergeExperiments Julia steps

### DIFF
--- a/bin/Benchmark.jl
+++ b/bin/Benchmark.jl
@@ -1,0 +1,76 @@
+# Benchmark.jl — shared lightweight instrumentation for the pipeline's Julia
+# scripts (included via `include("$(@__DIR__)/Benchmark.jl")`).
+#
+# Enabled by a `--benchmark` CLI flag; the including script sets the global
+# BENCHMARK accordingly. Zero overhead when BENCHMARK is false: `@bench name expr`
+# expands to the bare `expr`. When enabled, it accumulates (total_ns, count) per
+# named bucket so an end-of-run report can attribute both wall-clock time AND
+# call counts — the latter exposes work that scales with sample/strain count even
+# on a tiny local dataset where absolute time is small.
+
+using Printf
+
+global BENCHMARK = false
+
+# name -> [total_ns, count]
+const BENCH_DATA = Dict{String, Vector{Int}}()
+
+function _bench_record(name::AbstractString, ns::Integer)
+    d = get!(BENCH_DATA, name, Int[0, 0])
+    d[1] += ns
+    d[2] += 1
+    nothing
+end
+
+# Bump a pure counter (no timing) — for scale metrics like variations_built.
+function bench_count!(name::AbstractString, n::Integer=1)
+    BENCHMARK || return nothing
+    d = get!(BENCH_DATA, name, Int[0, 0])
+    d[2] += n
+    nothing
+end
+
+macro bench(name, expr)
+    quote
+        if BENCHMARK
+            local t0 = time_ns()
+            local v  = $(esc(expr))
+            _bench_record($(esc(name)), Int(time_ns() - t0))
+            v
+        else
+            $(esc(expr))
+        end
+    end
+end
+
+"""
+    print_benchmark_report(io, total_ns; summary, per_label, per_denom)
+
+Print the accumulated buckets sorted by total time. `summary` is a free-text
+header line (e.g. counts of the units processed). The last column normalizes each
+bucket's call count by `per_denom` and is titled `per_label` (e.g. "calls/pos",
+"calls/strain") — the signal that reveals per-unit scaling.
+"""
+function print_benchmark_report(io::IO, total_ns::Integer;
+                                summary::AbstractString="",
+                                per_label::AbstractString="calls/item",
+                                per_denom::Integer=0)
+    println(io, "")
+    println(io, "==================== BENCHMARK REPORT ====================")
+    @printf(io, "total wall-clock: %.2f s", total_ns / 1e9)
+    isempty(summary) || print(io, "   ", summary)
+    println(io)
+    @printf(io, "%-26s %10s %6s %12s %10s %11s\n",
+            "bucket", "total(s)", "%", "calls", "us/call", per_label)
+    println(io, "-"^80)
+    rows = sort(collect(BENCH_DATA); by = r -> -r[2][1])  # by total_ns desc
+    for (name, d) in rows
+        tns, cnt = d[1], d[2]
+        pct     = total_ns > 0 ? tns / total_ns * 100 : 0.0
+        us_call = cnt > 0 ? tns / cnt / 1e3 : 0.0
+        per     = per_denom > 0 ? cnt / per_denom : 0.0
+        @printf(io, "%-26s %10.3f %6.1f %12d %10.2f %11.3f\n",
+                name, tns / 1e9, pct, cnt, us_call, per)
+    end
+    println(io, "==========================================================")
+end

--- a/bin/makeCodingData.jl
+++ b/bin/makeCodingData.jl
@@ -228,6 +228,14 @@ function finalize_indels_db(db::SQLite.DB)
     execute(db, "CREATE INDEX idx_indels ON indels(transcript_id, strain, position)")
 end
 
+function finalize_cds_db(db::SQLite.DB)
+    # processSequenceVariations.jl queries coding_sequences by transcript_id alone.
+    # The PRIMARY KEY (strain, transcript_id) autoindex leads with strain, so a
+    # transcript_id-only lookup cannot use it and full-scans the (large) table.
+    # This index makes that lookup a seek.
+    execute(db, "CREATE INDEX idx_coding_sequences_transcript ON coding_sequences(transcript_id)")
+end
+
 # ---------------------------------------------------------------------------
 # Per-strain processing
 # ---------------------------------------------------------------------------
@@ -299,6 +307,7 @@ function main()
     end
 
     finalize_indels_db(indels_db)
+    finalize_cds_db(cds_db)
     println(stderr, "Done. Wrote $cds_db_out and $indels_db_out")
 end
 

--- a/bin/makeCodingData.jl
+++ b/bin/makeCodingData.jl
@@ -15,6 +15,7 @@
 #   codingIndels.db       — SQLite: indels(strain, transcript_id, position, shift_amount)
 
 include("$(@__DIR__)/GtfUtils.jl")
+include("$(@__DIR__)/Benchmark.jl")
 
 using SQLite
 using SQLite.DBInterface: execute
@@ -106,7 +107,7 @@ strictly less than `before_pos`. Used to convert a reference genomic coordinate
 to the corresponding position in a consensus FASTA that embeds genomic indels.
 """
 function fasta_offset(indel_db::SQLite.DB, strain::String, seq_id::String, before_pos::Int)
-    row = first(execute(indel_db,
+    row = @bench "sql_fasta_offset" first(execute(indel_db,
         "SELECT COALESCE(SUM(shift), 0) FROM genomic_indels
          WHERE strain = ? AND sequence_id = ? AND position < ?",
         [strain, seq_id, before_pos]))
@@ -168,14 +169,15 @@ function project_indels_to_cds(db::SQLite.DB, strain::String, exon_list::Vector{
     cds_offset = 0
 
     for e in exon_list
-        rows = execute(db,
+        # Materialize into value tuples inside the comprehension: this forces the
+        # lazy SQLite cursor (so @bench captures the full query+fetch cost) and
+        # copies the primitives out — SQLite.Row handles are invalid post-iteration.
+        rows = @bench "sql_project_indels" [(row[1], row[2]) for row in execute(db,
             "SELECT position, shift FROM genomic_indels
              WHERE strain = ? AND sequence_id = ? AND position >= ? AND position <= ?
              ORDER BY position",
-            [strain, seq_id, e.start, e.stop])
-        for row in rows
-            gpos  = row[1]
-            shift = row[2]
+            [strain, seq_id, e.start, e.stop])]
+        for (gpos, shift) in rows
             cds_pos = if e.strand == '-'
                 cds_offset + (e.stop - gpos)
             else
@@ -225,7 +227,7 @@ function create_indels_db(path::String)
 end
 
 function finalize_indels_db(db::SQLite.DB)
-    execute(db, "CREATE INDEX idx_indels ON indels(transcript_id, strain, position)")
+    @bench "finalize_indels_index" execute(db, "CREATE INDEX idx_indels ON indels(transcript_id, strain, position)")
 end
 
 function finalize_cds_db(db::SQLite.DB)
@@ -233,7 +235,7 @@ function finalize_cds_db(db::SQLite.DB)
     # The PRIMARY KEY (strain, transcript_id) autoindex leads with strain, so a
     # transcript_id-only lookup cannot use it and full-scans the (large) table.
     # This index makes that lookup a seek.
-    execute(db, "CREATE INDEX idx_coding_sequences_transcript ON coding_sequences(transcript_id)")
+    @bench "finalize_cds_index" execute(db, "CREATE INDEX idx_coding_sequences_transcript ON coding_sequences(transcript_id)")
 end
 
 # ---------------------------------------------------------------------------
@@ -244,13 +246,13 @@ function process_strain(strain, genome_seqs, by_transcript, indel_src_db,
                         cds_insert_stmt, indels_insert_stmt)
     db_for_coords = strain == "reference" ? nothing : indel_src_db
     for (transcript_id, exon_list) in by_transcript
-        seq = extract_cds_sequence(genome_seqs, exon_list, strain, db_for_coords)
+        seq = @bench "extract_cds" extract_cds_sequence(genome_seqs, exon_list, strain, db_for_coords)
         isempty(seq) && continue
-        execute(cds_insert_stmt, [strain, transcript_id, seq])
+        @bench "cds_insert" execute(cds_insert_stmt, [strain, transcript_id, seq])
 
-        cds_indels = project_indels_to_cds(indel_src_db, strain, exon_list)
+        cds_indels = @bench "project_indels" project_indels_to_cds(indel_src_db, strain, exon_list)
         for (pos, shift) in cds_indels
-            execute(indels_insert_stmt, [strain, transcript_id, pos, shift])
+            @bench "indels_insert" execute(indels_insert_stmt, [strain, transcript_id, pos, shift])
         end
     end
 end
@@ -261,6 +263,8 @@ end
 
 function main()
     args = parse_args(ARGS)
+    global BENCHMARK = haskey(args, "benchmark")
+    bench_t0 = time_ns()
 
     genomic_indel_db = args["genomic_indel_db"]
     gtf_file         = args["gtf_file"]
@@ -269,10 +273,10 @@ function main()
     indels_db_out    = args["indels_db_out"]
 
     println(stderr, "Parsing GTF: $gtf_file")
-    _, by_transcript = parse_gtf(gtf_file)
+    _, by_transcript = @bench "parse_gtf" parse_gtf(gtf_file)
 
     println(stderr, "Reading reference genome: $genome_fasta")
-    ref_seqs = read_fasta(genome_fasta)
+    ref_seqs = @bench "read_fasta" read_fasta(genome_fasta)
 
     println(stderr, "Opening genomic indels DB: $genomic_indel_db")
     indel_src_db = SQLite.DB(genomic_indel_db)
@@ -297,7 +301,7 @@ function main()
     for fasta_path in fasta_files
         strain = replace(basename(fasta_path), "_consensus.fa.gz" => "")
         println(stderr, "Processing strain: $strain")
-        strain_seqs = strip_strain_prefix(read_fasta(fasta_path), strain)
+        strain_seqs = strip_strain_prefix(@bench("read_fasta", read_fasta(fasta_path)), strain)
         SQLite.transaction(cds_db) do
             SQLite.transaction(indels_db) do
                 process_strain(strain, strain_seqs, by_transcript, indel_src_db,
@@ -309,6 +313,13 @@ function main()
     finalize_indels_db(indels_db)
     finalize_cds_db(cds_db)
     println(stderr, "Done. Wrote $cds_db_out and $indels_db_out")
+
+    if BENCHMARK
+        n_strains = 1 + length(fasta_files)   # reference + per-strain consensus FASTAs
+        print_benchmark_report(stderr, time_ns() - bench_t0;
+            summary = "strains (incl. reference): $n_strains   transcripts: $(length(by_transcript))",
+            per_label = "calls/strain", per_denom = n_strains)
+    end
 end
 
 if abspath(PROGRAM_FILE) == @__FILE__

--- a/bin/makeCodingData.jl
+++ b/bin/makeCodingData.jl
@@ -99,44 +99,91 @@ end
 # CDS sequence extraction
 # ---------------------------------------------------------------------------
 
-"""
-    fasta_offset(indel_db, strain, seq_id, before_pos) -> Int
+# ---------------------------------------------------------------------------
+# In-memory genomic-indel index (one strain at a time)
+#
+# makeCodingData processes a single strain across all transcripts, so instead of
+# issuing a SQL query per exon/transcript (fasta_offset + project_indels_to_cds
+# fired ~O(strains × transcripts × exons) queries — the makeCodingData
+# bottleneck), we pull a strain's genomic indels ONCE and answer both lookups
+# from sorted per-sequence arrays via binary search.
+# ---------------------------------------------------------------------------
 
-Return the cumulative indel shift for `strain` on `seq_id` at all positions
-strictly less than `before_pos`. Used to convert a reference genomic coordinate
-to the corresponding position in a consensus FASTA that embeds genomic indels.
-"""
-function fasta_offset(indel_db::SQLite.DB, strain::String, seq_id::String, before_pos::Int)
-    row = @bench "sql_fasta_offset" first(execute(indel_db,
-        "SELECT COALESCE(SUM(shift), 0) FROM genomic_indels
-         WHERE strain = ? AND sequence_id = ? AND position < ?",
-        [strain, seq_id, before_pos]))
-    row[1]
+struct GenomicIndelIndex
+    # sequence_id -> (positions, shifts, cumshifts) — all ascending by position;
+    # cumshifts is the running prefix sum of shifts.
+    byseq::Dict{String, Tuple{Vector{Int}, Vector{Int}, Vector{Int}}}
 end
 
 """
-    extract_cds_sequence(genome_seqs, exon_list, strain, indel_db) -> String
+    load_strain_genomic_indels(indel_db, strain) -> GenomicIndelIndex
+
+Load all genomic indels for `strain` in one query and build per-sequence sorted
+position/shift arrays plus a prefix sum of shifts.
+"""
+function load_strain_genomic_indels(indel_db::SQLite.DB, strain::String)::GenomicIndelIndex
+    byseq = Dict{String, Tuple{Vector{Int}, Vector{Int}, Vector{Int}}}()
+    rows = @bench "sql_load_strain_indels" [(String(r[1]), Int(r[2]), Int(r[3])) for r in execute(indel_db,
+        "SELECT sequence_id, position, shift FROM genomic_indels
+         WHERE strain = ? ORDER BY sequence_id, position",
+        [strain])]
+    for (seq_id, pos, shift) in rows
+        entry = get(byseq, seq_id, nothing)
+        if entry === nothing
+            entry = (Int[], Int[], Int[])
+            byseq[seq_id] = entry
+        end
+        push!(entry[1], pos)
+        push!(entry[2], shift)
+    end
+    for (_, (positions, shifts, cums)) in byseq
+        c = 0
+        for s in shifts
+            c += s
+            push!(cums, c)
+        end
+    end
+    GenomicIndelIndex(byseq)
+end
+
+"""
+    fasta_offset(idx, seq_id, before_pos) -> Int
+
+Cumulative indel shift on `seq_id` at all positions strictly less than
+`before_pos`. Converts a reference genomic coordinate to the corresponding
+position in a consensus FASTA that embeds genomic indels. Matches the old SQL
+`SUM(shift) WHERE ... AND position < ?` (0 when none) via binary search.
+"""
+function fasta_offset(idx::GenomicIndelIndex, seq_id::String, before_pos::Int)::Int
+    entry = get(idx.byseq, seq_id, nothing)
+    entry === nothing && return 0
+    positions, _, cums = entry
+    i = searchsortedlast(positions, before_pos - 1)  # position < before_pos
+    i == 0 ? 0 : cums[i]
+end
+
+"""
+    extract_cds_sequence(genome_seqs, exon_list, indel_idx) -> String
 
 Splice and return the CDS sequence for a transcript from genome sequences.
 `exon_list` must be in 5'→3' order (as returned by parse_gtf).
 Reverse-complements minus-strand transcripts using IUPAC-aware complement.
 Returns "" if any exon's seq_id is missing from genome_seqs.
 
-For non-reference strains, pass `strain` and `indel_db` so that exon slice
-coordinates are adjusted for upstream genomic indels embedded in the consensus
-FASTA.
+For non-reference strains, pass the strain's `indel_idx` (a GenomicIndelIndex) so
+exon slice coordinates are adjusted for upstream genomic indels embedded in the
+consensus FASTA. Pass `nothing` for the reference (coordinates used as-is).
 """
 function extract_cds_sequence(genome_seqs::Dict{String,String}, exon_list::Vector{CdsExon},
-                               strain::String="reference",
-                               indel_db::Union{SQLite.DB,Nothing}=nothing)
+                               indel_idx::Union{GenomicIndelIndex,Nothing}=nothing)
     isempty(exon_list) && return ""
     parts = String[]
     for e in exon_list
         seq = get(genome_seqs, e.seq_id, nothing)
         seq === nothing && return ""
-        if indel_db !== nothing
-            fstart = e.start + fasta_offset(indel_db, strain, e.seq_id, e.start)
-            fstop  = e.stop  + fasta_offset(indel_db, strain, e.seq_id, e.stop + 1)
+        if indel_idx !== nothing
+            fstart = e.start + fasta_offset(indel_idx, e.seq_id, e.start)
+            fstop  = e.stop  + fasta_offset(indel_idx, e.seq_id, e.stop + 1)
         else
             fstart, fstop = e.start, e.stop
         end
@@ -155,29 +202,30 @@ end
 # ---------------------------------------------------------------------------
 
 """
-    project_indels_to_cds(db, strain, exon_list) -> Vector{Tuple{Int,Int}}
+    project_indels_to_cds(indel_idx, exon_list) -> Vector{Tuple{Int,Int}}
 
-Query genomic indels for `strain` that fall within the exons of a transcript,
-convert each to a 0-based CDS-space position, and return
+Find the strain's genomic indels (from `indel_idx`) that fall within the exons of
+a transcript, convert each to a 0-based CDS-space position, and return
 [(cds_position, shift_amount), ...] sorted in 5'→3' order.
 """
-function project_indels_to_cds(db::SQLite.DB, strain::String, exon_list::Vector{CdsExon})
+function project_indels_to_cds(indel_idx::GenomicIndelIndex, exon_list::Vector{CdsExon})
     result = Tuple{Int,Int}[]
     isempty(exon_list) && return result
 
     seq_id     = exon_list[1].seq_id
     cds_offset = 0
 
+    entry = get(indel_idx.byseq, seq_id, nothing)
+    positions, shifts = entry === nothing ? (Int[], Int[]) : (entry[1], entry[2])
+
     for e in exon_list
-        # Materialize into value tuples inside the comprehension: this forces the
-        # lazy SQLite cursor (so @bench captures the full query+fetch cost) and
-        # copies the primitives out — SQLite.Row handles are invalid post-iteration.
-        rows = @bench "sql_project_indels" [(row[1], row[2]) for row in execute(db,
-            "SELECT position, shift FROM genomic_indels
-             WHERE strain = ? AND sequence_id = ? AND position >= ? AND position <= ?
-             ORDER BY position",
-            [strain, seq_id, e.start, e.stop])]
-        for (gpos, shift) in rows
+        # In-memory equivalent of the old
+        #   WHERE position >= e.start AND position <= e.stop ORDER BY position
+        lo = searchsortedfirst(positions, e.start)
+        hi = searchsortedlast(positions, e.stop)
+        for i in lo:hi
+            gpos  = positions[i]
+            shift = shifts[i]
             cds_pos = if e.strand == '-'
                 cds_offset + (e.stop - gpos)
             else
@@ -244,13 +292,17 @@ end
 
 function process_strain(strain, genome_seqs, by_transcript, indel_src_db,
                         cds_insert_stmt, indels_insert_stmt)
-    db_for_coords = strain == "reference" ? nothing : indel_src_db
+    # One query per strain instead of per (transcript, exon). The reference gets no
+    # coordinate offset in extract_cds (indel_idx=nothing), matching prior behavior;
+    # project_indels still uses the loaded index (empty for the reference).
+    indel_idx  = load_strain_genomic_indels(indel_src_db, strain)
+    extract_idx = strain == "reference" ? nothing : indel_idx
     for (transcript_id, exon_list) in by_transcript
-        seq = @bench "extract_cds" extract_cds_sequence(genome_seqs, exon_list, strain, db_for_coords)
+        seq = @bench "extract_cds" extract_cds_sequence(genome_seqs, exon_list, extract_idx)
         isempty(seq) && continue
         @bench "cds_insert" execute(cds_insert_stmt, [strain, transcript_id, seq])
 
-        cds_indels = @bench "project_indels" project_indels_to_cds(indel_src_db, strain, exon_list)
+        cds_indels = @bench "project_indels" project_indels_to_cds(indel_idx, exon_list)
         for (pos, shift) in cds_indels
             @bench "indels_insert" execute(indels_insert_stmt, [strain, transcript_id, pos, shift])
         end

--- a/bin/processSequenceVariations.jl
+++ b/bin/processSequenceVariations.jl
@@ -12,6 +12,8 @@ using SQLite
 using SQLite.DBInterface: execute
 using Printf
 
+include("$(@__DIR__)/Benchmark.jl")
+
 # ---------------------------------------------------------------------------
 # Global debug flag
 # ---------------------------------------------------------------------------
@@ -20,67 +22,6 @@ global DEBUG = false
 
 function debug_log(msg...)
     DEBUG && println(stderr, "[DEBUG] ", msg...)
-end
-
-# ---------------------------------------------------------------------------
-# Benchmarking (enabled by --benchmark). Zero overhead when BENCHMARK is false:
-# `@bench name expr` expands to the bare `expr`. When enabled, it accumulates
-# (total_ns, count) per named bucket so the end-of-run report can attribute both
-# wall-clock time AND per-position call counts — the latter exposes O(samples)
-# hotspots even on a tiny local dataset where absolute time is small.
-# ---------------------------------------------------------------------------
-
-global BENCHMARK = false
-
-# name -> [total_ns, count]
-const BENCH_DATA = Dict{String, Vector{Int}}()
-
-function _bench_record(name::AbstractString, ns::Integer)
-    d = get!(BENCH_DATA, name, Int[0, 0])
-    d[1] += ns
-    d[2] += 1
-    nothing
-end
-
-# Bump a pure counter (no timing) — for scale metrics like variations_built.
-function bench_count!(name::AbstractString, n::Integer=1)
-    BENCHMARK || return nothing
-    d = get!(BENCH_DATA, name, Int[0, 0])
-    d[2] += n
-    nothing
-end
-
-macro bench(name, expr)
-    quote
-        if BENCHMARK
-            local t0 = time_ns()
-            local v  = $(esc(expr))
-            _bench_record($(esc(name)), Int(time_ns() - t0))
-            v
-        else
-            $(esc(expr))
-        end
-    end
-end
-
-function print_benchmark_report(io::IO, total_ns::Integer, n_seen::Integer, n_processed::Integer)
-    println(io, "")
-    println(io, "==================== BENCHMARK REPORT ====================")
-    @printf(io, "total wall-clock: %.2f s   positions seen: %d   positions with output: %d\n",
-            total_ns / 1e9, n_seen, n_processed)
-    @printf(io, "%-26s %10s %6s %12s %10s %11s\n",
-            "bucket", "total(s)", "%", "calls", "us/call", "calls/pos")
-    println(io, "-"^80)
-    rows = sort(collect(BENCH_DATA); by = r -> -r[2][1])  # by total_ns desc
-    for (name, d) in rows
-        tns, cnt = d[1], d[2]
-        pct     = total_ns > 0 ? tns / total_ns * 100 : 0.0
-        us_call = cnt > 0 ? tns / cnt / 1e3 : 0.0
-        per_pos = n_seen > 0 ? cnt / n_seen : 0.0
-        @printf(io, "%-26s %10.3f %6.1f %12d %10.2f %11.3f\n",
-                name, tns / 1e9, pct, cnt, us_call, per_pos)
-    end
-    println(io, "==========================================================")
 end
 
 # ---------------------------------------------------------------------------
@@ -2524,7 +2465,9 @@ function main()
     debug_log("Processing complete. Total positions processed: ", n_processed)
 
     if BENCHMARK
-        print_benchmark_report(stderr, time_ns() - bench_t0, n_seen, n_processed)
+        print_benchmark_report(stderr, time_ns() - bench_t0;
+            summary = "positions seen: $n_seen   positions with output: $n_processed",
+            per_label = "calls/pos", per_denom = n_seen)
     end
 
     close_peeked(vcf_pf)

--- a/bin/processSequenceVariations.jl
+++ b/bin/processSequenceVariations.jl
@@ -485,11 +485,69 @@ function load_transcript_sequences(db::SQLite.DB, transcript_id::String)
     result
 end
 
-function get_indel_shift(db::SQLite.DB, transcript_id::String, strain::String, position::Int)
-    row = @bench "sql_get_indel_shift" first(execute(db,
-        "SELECT COALESCE(SUM(shift_amount), 0) FROM indels WHERE transcript_id = ? AND strain = ? AND position < ?",
-        [transcript_id, strain, position]))
-    row[1]::Int
+# Precomputed cumulative indel shifts, replacing a per-variation SQL aggregate.
+# For each (strain, transcript_id): parallel vectors of event positions (ascending)
+# and the running sum of shift_amount up to and including each position. A lookup
+# for `position < p` is then a binary search — no SQLite round-trip in the hot
+# path (that query fired ~O(samples) times per position; see benchmark findings).
+const IndelShiftTable = Dict{Tuple{String,String}, Tuple{Vector{Int}, Vector{Int}}}
+
+function precompute_indel_shifts(indel_db::SQLite.DB)::IndelShiftTable
+    debug_log("Precomputing indel shifts...")
+    shifts = IndelShiftTable()
+
+    current_strain = ""
+    current_tid = ""
+    positions = Int[]
+    cums = Int[]
+    cumsum = 0
+
+    function flush_current()
+        if !isempty(positions)
+            shifts[(current_strain, current_tid)] = (positions, cums)
+        end
+    end
+
+    for row in execute(indel_db,
+        "SELECT strain, transcript_id, position, shift_amount FROM indels ORDER BY strain, transcript_id, position")
+        strain = row[1]::String
+        tid = row[2]::String
+        pos = row[3]::Int
+        shift = row[4]::Int
+
+        if strain != current_strain || tid != current_tid
+            flush_current()
+            current_strain = strain
+            current_tid = tid
+            positions = Int[]
+            cums = Int[]
+            cumsum = 0
+        end
+
+        cumsum += shift
+        push!(positions, pos)
+        push!(cums, cumsum)
+    end
+    flush_current()
+
+    debug_log("Indel shift precomputation complete: ", length(shifts), " strain-transcript pairs with indels")
+    shifts
+end
+
+"""
+    lookup_indel_shift(shifts, transcript_id, strain, position) -> Int
+
+Cumulative shift_amount for all indels of (strain, transcript_id) at CDS positions
+strictly less than `position`. Replaces the old SQL
+`SUM(shift_amount) WHERE ... AND position < ?` (0 when none) with a binary search.
+"""
+function lookup_indel_shift(shifts::IndelShiftTable, transcript_id::String, strain::String, position::Int)::Int
+    entry = get(shifts, (strain, transcript_id), nothing)
+    isnothing(entry) && return 0
+    positions, cums = entry
+    # integer positions: `pos < position` ⇔ `pos <= position - 1`
+    idx = searchsortedlast(positions, position - 1)
+    idx == 0 ? 0 : cums[idx]
 end
 
 # ---------------------------------------------------------------------------
@@ -653,6 +711,7 @@ struct ProcessingContext
     transcript_db::SQLite.DB
     indel_db::SQLite.DB
     fs_info::Dict{String, Dict{String, Tuple{Bool, Int}}}
+    indel_shifts::IndelShiftTable
     all_strains::Vector{String}
     sample_id_map::Dict{String,Int}
     ploidy::Int
@@ -1311,7 +1370,8 @@ function initialize_processing_context(args, all_strains::Vector{String})
     transcript_db = SQLite.DB(args["transcript_db"])
     indel_db      = SQLite.DB(args["indel_db"])
 
-    fs_info = @bench "precompute_frameshifts" precompute_frameshifts(indel_db, transcript_info)
+    fs_info      = @bench "precompute_frameshifts" precompute_frameshifts(indel_db, transcript_info)
+    indel_shifts = @bench "precompute_indel_shifts" precompute_indel_shifts(indel_db)
 
     ploidy = haskey(args, "ploidy") ? parse(Int, args["ploidy"]) : 1
 
@@ -1322,6 +1382,7 @@ function initialize_processing_context(args, all_strains::Vector{String})
         transcript_db,
         indel_db,
         fs_info,
+        indel_shifts,
         all_strains,
         Dict{String,Int}(name => i for (i, name) in enumerate([all_strains..., args["reference_strain"]])),
         ploidy
@@ -1451,7 +1512,7 @@ function annotate_variations!(
                 v.codon   = "."
                 v.product = String[]
             else
-                shift        = get_indel_shift(ctx.indel_db, annotation.transcript_id, v.strain, annotation.pos_in_cds)
+                shift        = lookup_indel_shift(ctx.indel_shifts, annotation.transcript_id, v.strain, annotation.pos_in_cds)
                 adjusted_pos = annotation.pos_in_cds + shift
                 strain_codon = extract_codon(strain_seq, adjusted_pos)
                 v.codon   = strain_codon

--- a/bin/processSequenceVariations.jl
+++ b/bin/processSequenceVariations.jl
@@ -23,6 +23,67 @@ function debug_log(msg...)
 end
 
 # ---------------------------------------------------------------------------
+# Benchmarking (enabled by --benchmark). Zero overhead when BENCHMARK is false:
+# `@bench name expr` expands to the bare `expr`. When enabled, it accumulates
+# (total_ns, count) per named bucket so the end-of-run report can attribute both
+# wall-clock time AND per-position call counts — the latter exposes O(samples)
+# hotspots even on a tiny local dataset where absolute time is small.
+# ---------------------------------------------------------------------------
+
+global BENCHMARK = false
+
+# name -> [total_ns, count]
+const BENCH_DATA = Dict{String, Vector{Int}}()
+
+function _bench_record(name::AbstractString, ns::Integer)
+    d = get!(BENCH_DATA, name, Int[0, 0])
+    d[1] += ns
+    d[2] += 1
+    nothing
+end
+
+# Bump a pure counter (no timing) — for scale metrics like variations_built.
+function bench_count!(name::AbstractString, n::Integer=1)
+    BENCHMARK || return nothing
+    d = get!(BENCH_DATA, name, Int[0, 0])
+    d[2] += n
+    nothing
+end
+
+macro bench(name, expr)
+    quote
+        if BENCHMARK
+            local t0 = time_ns()
+            local v  = $(esc(expr))
+            _bench_record($(esc(name)), Int(time_ns() - t0))
+            v
+        else
+            $(esc(expr))
+        end
+    end
+end
+
+function print_benchmark_report(io::IO, total_ns::Integer, n_seen::Integer, n_processed::Integer)
+    println(io, "")
+    println(io, "==================== BENCHMARK REPORT ====================")
+    @printf(io, "total wall-clock: %.2f s   positions seen: %d   positions with output: %d\n",
+            total_ns / 1e9, n_seen, n_processed)
+    @printf(io, "%-26s %10s %6s %12s %10s %11s\n",
+            "bucket", "total(s)", "%", "calls", "us/call", "calls/pos")
+    println(io, "-"^80)
+    rows = sort(collect(BENCH_DATA); by = r -> -r[2][1])  # by total_ns desc
+    for (name, d) in rows
+        tns, cnt = d[1], d[2]
+        pct     = total_ns > 0 ? tns / total_ns * 100 : 0.0
+        us_call = cnt > 0 ? tns / cnt / 1e3 : 0.0
+        per_pos = n_seen > 0 ? cnt / n_seen : 0.0
+        @printf(io, "%-26s %10.3f %6.1f %12d %10.2f %11.3f\n",
+                name, tns / 1e9, pct, cnt, us_call, per_pos)
+    end
+    println(io, "==========================================================")
+end
+
+# ---------------------------------------------------------------------------
 # CLI argument parsing (hand-rolled, no package dependency)
 # ---------------------------------------------------------------------------
 
@@ -418,14 +479,14 @@ end
 
 function load_transcript_sequences(db::SQLite.DB, transcript_id::String)
     result = Dict{String,String}()
-    for row in execute(db, "SELECT strain, sequence FROM coding_sequences WHERE transcript_id = ?", [transcript_id])
+    @bench "sql_load_transcript" for row in execute(db, "SELECT strain, sequence FROM coding_sequences WHERE transcript_id = ?", [transcript_id])
         result[row[1]::String] = row[2]::String
     end
     result
 end
 
 function get_indel_shift(db::SQLite.DB, transcript_id::String, strain::String, position::Int)
-    row = first(execute(db,
+    row = @bench "sql_get_indel_shift" first(execute(db,
         "SELECT COALESCE(SUM(shift_amount), 0) FROM indels WHERE transcript_id = ? AND strain = ? AND position < ?",
         [transcript_id, strain, position]))
     row[1]::Int
@@ -1212,6 +1273,7 @@ function build_variations_from_record(
         push!(variations, v)
     end
 
+    bench_count!("variations_built", length(variations))
     variations
 end
 
@@ -1244,12 +1306,12 @@ end
     initialize_processing_context(args, all_strains) -> ProcessingContext
 """
 function initialize_processing_context(args, all_strains::Vector{String})
-    (cds_intervals, transcript_info) = parse_gtf(args["gtf_file"])
+    (cds_intervals, transcript_info) = @bench "parse_gtf" parse_gtf(args["gtf_file"])
 
     transcript_db = SQLite.DB(args["transcript_db"])
     indel_db      = SQLite.DB(args["indel_db"])
 
-    fs_info = precompute_frameshifts(indel_db, transcript_info)
+    fs_info = @bench "precompute_frameshifts" precompute_frameshifts(indel_db, transcript_info)
 
     ploidy = haskey(args, "ploidy") ? parse(Int, args["ploidy"]) : 1
 
@@ -2182,7 +2244,7 @@ function handle_variant_record!(
 
     per_record = Tuple{VCFRecord, Vector{Variation}}[]
     for r in records
-        rv = build_variations_from_record(
+        rv = @bench "build_variations" build_variations_from_record(
             r, all_strains, chrom_coverage, ctx.ploidy;
             synthesize_ref = (r === ref_record), no_synth_strains = real_call_strains)
         push!(per_record, (r, rv))
@@ -2191,12 +2253,12 @@ function handle_variant_record!(
     isempty(variations) && return false
 
     # Determine annotations: one per overlapping transcript (cache or fresh GTF lookup)
-    annotations = if !isempty(cache_entries)
+    annotations = @bench "annotate" (if !isempty(cache_entries)
         debug_log("    Cache hit at ", seq_id, ":", location)
         build_annotations_from_cache(cache_entries, ctx.reference_strain, ctx.transcript_db, transcript_cache)
     else
         annotate_position_all(seq_id, location, ctx, transcript_cache)
-    end
+    end)
 
     # Accumulate per-sample CANN entries across all annotations (transcripts).
     # alt_strain_entries: alt -> strain -> [entry per transcript, in annotation order]
@@ -2216,7 +2278,7 @@ function handle_variant_record!(
     allele_written = false
 
     for annotation in annotations
-        annotate_variations!(variations, annotation, ctx, transcript_cache)
+        @bench "annotate_variations" annotate_variations!(variations, annotation, ctx, transcript_cache)
 
         for v in variations
             if !isempty(v.transcript)
@@ -2240,15 +2302,15 @@ function handle_variant_record!(
         end
 
         if !allele_written
-            write_allele_file(writers.allele_fh, all_vars, seq_id, location, ctx.sample_id_map)
+            @bench "write_allele" write_allele_file(writers.allele_fh, all_vars, seq_id, location, ctx.sample_id_map)
             allele_written = true
         end
-        write_transcript_product(writers.transcript_product_fh, all_vars, annotation, seq_id, location, ctx.sample_id_map)
+        @bench "write_transcript_product" write_transcript_product(writers.transcript_product_fh, all_vars, annotation, seq_id, location, ctx.sample_id_map)
 
         # Collect per-sample CANN entry keyed by original VCF alt allele (not IUPAC-derived base).
         # v.base may be an IUPAC ambiguity code for het calls; the VCF output write loop below
         # iterates each record's alts, so we must use the original allele strings as keys here.
-        for (rec, recvars) in per_record
+        @bench "cann_collect" for (rec, recvars) in per_record
             for (alt, smap) in collect_cann_entries_for_annotation(recvars, annotation, rec, ctx.reference_strain, all_strains, strain_idx_map)
                 for (strain, entries) in smap
                     strain_map = get!(alt_strain_entries, alt, Dict{String, Vector{String}}())
@@ -2261,7 +2323,7 @@ function handle_variant_record!(
     any_output || return false
 
     is_coding = any(a.is_coding == 1 for a in annotations) ? 1 : 0
-    write_snp_feature(writers.snp_fh, first_all_vars, is_coding, seq_id, location,
+    @bench "write_snp_feature" write_snp_feature(writers.snp_fh, first_all_vars, is_coding, seq_id, location,
                       ctx.reference_strain, ctx.all_strains)
 
     # HSSS binary files are SNP-only; skip positions where no record has a SNP-length allele.
@@ -2269,15 +2331,15 @@ function handle_variant_record!(
         unique_prods   = unique(all_annotation_products)
         hsss_prod_code = length(unique_prods) == 1 ?
             Int8(codepoint(first(only(unique_prods)))) : Int8(0)
-        write_hsss_position!(writers.hsss, first_all_vars, ctx.reference_strain,
+        @bench "write_hsss" write_hsss_position!(writers.hsss, first_all_vars, ctx.reference_strain,
                              seq_id, location, ctx.all_strains, hsss_prod_code)  # ctx.all_strains is non-ref only; ref handled via ref_vars inside write_hsss_position!
     end
 
     (ref_keys, ref_cann_entries) = build_ref_cann_entries(annotations)
-    (alt_cann_entries, alt_strain_to_ca) = assign_cann_keys(alt_strain_entries, all_strains)
+    (alt_cann_entries, alt_strain_to_ca) = @bench "cann_assign" assign_cann_keys(alt_strain_entries, all_strains)
 
     # Write one VCF output entry per unique alt per class-record (for SnpEff).
-    for (rec, recvars) in per_record
+    @bench "vcf_output_write" for (rec, recvars) in per_record
         modified_sample_data = fill_missing_coverage_gt(rec, all_strains, chrom_coverage, ctx.ploidy)
         strain_to_dfs = Dict{String,String}(v.strain => string(v.downstream_of_frameshift) for v in recvars)
         dfs_values = [get(strain_to_dfs, s, ".") for s in all_strains]
@@ -2313,11 +2375,13 @@ end
 function main()
     args = parse_args(ARGS)
     global DEBUG = haskey(args, "debug")
+    global BENCHMARK = haskey(args, "benchmark")
     debug_log("Debug mode enabled")
+    bench_t0 = time_ns()   # whole-run clock (includes setup + main loop)
 
     # Open VCF and parse header
     debug_log("Opening VCF: ", args["vcf_file"])
-    (vcf_pf, all_strains, chrom_rank, info_headers) = open_vcf_peeked(args["vcf_file"])
+    (vcf_pf, all_strains, chrom_rank, info_headers) = @bench "vcf_open_header" open_vcf_peeked(args["vcf_file"])
     debug_log("VCF: ", length(all_strains), " strains")
     write_sample_dat([all_strains..., args["reference_strain"]])
 
@@ -2346,6 +2410,7 @@ function main()
     current_chrom  = ""
 
     n_processed = 0
+    n_seen      = 0
 
     while !vcf_pf.exhausted
         vcf_start = peek_sort_key(vcf_pf.line, chrom_rank)
@@ -2365,11 +2430,13 @@ function main()
             push!(records, parse_vcf_record(vcf_pf.line, length(all_strains)))
             advance!(vcf_pf)
         end
+        n_seen += 1
+        bench_count!("records_parsed", length(records))
 
         # Load coverage intervals when the chromosome changes
         if records[1].chrom != current_chrom
             current_chrom = records[1].chrom
-            load_chrom_coverage!(coverage_fh, current_chrom, chrom_rank, chrom_coverage)
+            @bench "load_coverage" load_chrom_coverage!(coverage_fh, current_chrom, chrom_rank, chrom_coverage)
         end
 
         # Collect all cache entries at this (chrom, pos)
@@ -2394,6 +2461,10 @@ function main()
     end
 
     debug_log("Processing complete. Total positions processed: ", n_processed)
+
+    if BENCHMARK
+        print_benchmark_report(stderr, time_ns() - bench_t0, n_seen, n_processed)
+    end
 
     close_peeked(vcf_pf)
     close_peeked(cache_pf)

--- a/docs/superpowers/specs/2026-07-16-benchmark-processSequenceVariations-design.md
+++ b/docs/superpowers/specs/2026-07-16-benchmark-processSequenceVariations-design.md
@@ -167,12 +167,42 @@ uses for `GtfUtils.jl`). The report gained caller-supplied `summary` / `per_labe
 (`calls/pos` vs `calls/strain`).
 
 **`makeCodingData.jl`** is instrumented across `parse_gtf`, `read_fasta`,
-`extract_cds`, `project_indels`, the two SQL calls (`sql_fasta_offset`,
-`sql_project_indels`), the inserts, and the two index builds. A 4-strain run shows
-it is SQL-bound in the same shape as the original processSeqVars problem: one
-`sql_project_indels` per (strain, transcript) and ~2 `sql_fasta_offset` per
-(strain, exon), all O(strains). No fix applied yet — instrumentation only, so the
-hotspot can be confirmed at production scale before optimizing.
+`extract_cds`, `project_indels`, the SQL calls, the inserts, and the two index
+builds.
 
 The Nextflow param was renamed `benchmarkVariations` → **`benchmark`** (it now
 gates both merge Julia steps) and is threaded into both process invocations.
+
+### makeCodingData findings (20-sample run) + fix
+
+A from-scratch 20-sample run showed **makeCodingData at 1498 s (~25 min)**, ~99%
+SQLite — the same per-`(strain, transcript, exon)` round-trip pattern:
+
+| bucket | time | calls | note |
+|---|---|---|---|
+| `sql_project_indels` | 1033 s (69%) | 338,856 | one range query per (strain, transcript, exon) |
+| `sql_fasta_offset` | 446 s (30%) | 649,474 | ~2 per (strain, exon), all O(strains) |
+
+**Fix (in-memory index).** makeCodingData processes one strain at a time, so a
+`GenomicIndelIndex` loads that strain's genomic indels in **one** query into
+per-`sequence_id` sorted `(position, shift)` arrays plus a shift prefix-sum.
+`fasta_offset` becomes a binary search on the prefix-sum; `project_indels_to_cds`
+a binary-searched range slice. Their signatures now take the index instead of
+`(db, strain)`. ~988k queries → **24** (one per strain).
+
+`testing/t/genomicIndelIndex.jl` asserts both lookups equal the original SQL
+across every position and window (with duplicate positions, multiple sequences,
+strain isolation); existing makeCodingData tests updated to the new signatures.
+
+**Verification (same 20-sample inputs):** **1498 s → 11.5 s (~130×).** Both SQL
+hotspots eliminated; residual time is FASTA reading (44%) and CDS splicing (31%).
+`coding_sequences` and `indels` table contents **byte-identical** to the prior
+run (129,336 / 5,341 rows). Full Julia suite passes.
+
+### processSeqVars fix confirmed end-to-end
+
+The same 20-sample from-scratch run (fresh, indexed `codingSequences.db`) took
+processSeqVars from the original **1661.84 s → 52.30 s (~32×)**:
+`sql_load_transcript` 931 s → 2.0 s (index landed on the fresh build),
+`sql_get_indel_shift` eliminated. The shared `bin/Benchmark.jl` staged and ran
+correctly through Nextflow.

--- a/docs/superpowers/specs/2026-07-16-benchmark-processSequenceVariations-design.md
+++ b/docs/superpowers/specs/2026-07-16-benchmark-processSequenceVariations-design.md
@@ -108,3 +108,50 @@ legible even though the local wall-clock is small.
   `dnaseqanalysis` container and confirm the report prints with sane numbers and
   the phase percentages sum to ~100%.
 - Existing Julia/Python test suites must still pass unchanged.
+
+## Findings (20-sample run, 122,530 positions)
+
+Benchmark on a real 20-sample Plasmodium dataset took **1661.84 s (~28 min)** and
+was ~95% SQLite:
+
+| bucket | time | note |
+|---|---|---|
+| `sql_load_transcript` | 931 s (56%) | only 4034 calls but **231 ms each** |
+| `sql_get_indel_shift` | 627 s (38%) | **778,513 calls** (6.35/pos, linear in samples) at ~800 µs each |
+
+Two distinct pathologies, confirmed against the actual DBs:
+
+1. `coding_sequences` has `PRIMARY KEY (strain, transcript_id)`. The query filters
+   `WHERE transcript_id = ?` only, so the autoindex (leading with `strain`) cannot
+   serve it — every call full-scans the 364 MB table.
+2. The `indels` table is tiny (5341 rows) and already indexed; the cost was purely
+   778k statement round-trips, and the call count grows with sample count.
+
+The output writers originally suspected were <2% combined.
+
+## Fixes implemented (follow-up to the measure-only scope)
+
+1. **`bin/makeCodingData.jl`** — `finalize_cds_db` adds
+   `CREATE INDEX idx_coding_sequences_transcript ON coding_sequences(transcript_id)`
+   at DB-build time. The read-only consumer is not mutated.
+2. **`bin/processSequenceVariations.jl`** — `precompute_indel_shifts` scans the
+   `indels` table once into a per-`(strain, transcript_id)` prefix-sum table;
+   `lookup_indel_shift` answers `position < p` by binary search. `get_indel_shift`
+   (the per-variation SQL query) is removed.
+3. **`testing/t/indelShiftLookup.jl`** — characterization test asserting
+   `lookup_indel_shift` equals the original SQL at every position (1755 checks + edge cases).
+
+## Verification
+
+Re-ran the fixed code against the same 20-sample inputs (with the index added to a
+copy of the DB):
+
+- **1661.84 s → 84.07 s (~20× faster).** `sql_load_transcript` 931 s → 1.9 s;
+  `sql_get_indel_shift` 627 s → eliminated (0.27 s one-time precompute).
+- **All outputs byte-identical** (variationFeature/snpFeature.dat,
+  transcript_product.dat, allele.dat, sample.dat, output.vcf, all four HSSS
+  binary dirs). Full Julia test suite passes.
+
+Both costs were O(samples), so the projected effect at 1000–2000 samples is far
+larger than 20× (the index fix removes a per-call cost that itself grew with
+table size).

--- a/docs/superpowers/specs/2026-07-16-benchmark-processSequenceVariations-design.md
+++ b/docs/superpowers/specs/2026-07-16-benchmark-processSequenceVariations-design.md
@@ -155,3 +155,24 @@ copy of the DB):
 Both costs were O(samples), so the projected effect at 1000–2000 samples is far
 larger than 20× (the index fix removes a per-call cost that itself grew with
 table size).
+
+## Extension: shared module + makeCodingData
+
+The benchmarking primitives (`BENCHMARK`, `@bench`, `bench_count!`,
+`print_benchmark_report`) were extracted to **`bin/Benchmark.jl`** and are
+`include`d by both merge Julia scripts (Nextflow stages the whole `bin/` dir, so
+sibling includes resolve at runtime — same mechanism `makeCodingData.jl` already
+uses for `GtfUtils.jl`). The report gained caller-supplied `summary` / `per_label`
+/ `per_denom` keywords so the normalization column fits each script
+(`calls/pos` vs `calls/strain`).
+
+**`makeCodingData.jl`** is instrumented across `parse_gtf`, `read_fasta`,
+`extract_cds`, `project_indels`, the two SQL calls (`sql_fasta_offset`,
+`sql_project_indels`), the inserts, and the two index builds. A 4-strain run shows
+it is SQL-bound in the same shape as the original processSeqVars problem: one
+`sql_project_indels` per (strain, transcript) and ~2 `sql_fasta_offset` per
+(strain, exon), all O(strains). No fix applied yet — instrumentation only, so the
+hotspot can be confirmed at production scale before optimizing.
+
+The Nextflow param was renamed `benchmarkVariations` → **`benchmark`** (it now
+gates both merge Julia steps) and is threaded into both process invocations.

--- a/docs/superpowers/specs/2026-07-16-benchmark-processSequenceVariations-design.md
+++ b/docs/superpowers/specs/2026-07-16-benchmark-processSequenceVariations-design.md
@@ -1,0 +1,110 @@
+# Benchmark instrumentation for `processSequenceVariations.jl`
+
+**Date:** 2026-07-16
+**Status:** Approved design, pending implementation
+**Scope:** Measure only. No behavior change; no hotspot fix in this change.
+
+## Problem
+
+`mergeExperiments` takes ~14 hours for 200 DNA-seq samples, and most of that
+time is spent inside `bin/processSequenceVariations.jl`. Production runs for some
+organisms process 1000–2000 samples, so whatever scales poorly with sample count
+dominates. We need to know *where* the time goes before optimizing.
+
+A complication: the only convenient local dataset has 4 samples. Wall-clock on 4
+samples is small, so raw timing alone will not surface an O(samples) hotspot. The
+instrumentation must therefore also expose **per-position call counts**, which
+reveal per-sample scaling regardless of absolute time.
+
+## Prime suspects (from code reading)
+
+- `get_indel_shift` (`bin/processSequenceVariations.jl`) issues one SQLite query
+  **per variation per coding transcript**, inside `annotate_variations!`.
+- Reference synthesis in `build_variations_from_record` creates a `Variation` for
+  **every covered sample** at **every no-call position**.
+
+Together these make coding loci roughly O(samples) or worse in SQL round-trips.
+This design measures them precisely rather than assuming.
+
+## Mechanism
+
+A global `BENCHMARK` flag parallel to the existing `DEBUG` flag, set from a new
+`--benchmark` CLI argument. A `@bench` macro wraps an expression:
+
+```julia
+macro bench(name, expr)
+    quote
+        if BENCHMARK
+            local t0 = time_ns()
+            local v  = $(esc(expr))
+            _bench_record($(esc(name)), time_ns() - t0)
+            v
+        else
+            $(esc(expr))
+        end
+    end
+end
+```
+
+When `BENCHMARK` is false the macro expands to just `expr` — zero overhead on
+normal runs. `_bench_record(name, ns)` accumulates `(total_ns, count)` into a
+global `Dict{String,Tuple{Int,Int}}` (ns as Int, count as Int).
+`bench_count!(name, n=1)` bumps a pure counter (no timing) in the same store.
+
+## Instrumentation points
+
+Setup (once):
+- `parse_gtf`
+- `precompute_frameshifts`
+- VCF open + header parse
+
+Per-position phases (inside `handle_variant_record!` and the main loop):
+- `build_variations`
+- `annotate` (covers both the cache path and the fresh GTF lookup)
+- `annotate_variations`
+- `write_allele`
+- `write_transcript_product`
+- `write_snp_feature`
+- `cann_collect` (CANN entry collection + `assign_cann_keys`)
+- `write_hsss`
+- `vcf_output_write`
+
+Hot SQL calls, wrapped individually for time **and** count:
+- `sql_get_indel_shift`
+- `sql_load_transcript`
+
+Scale counters (count only):
+- `positions_processed`
+- `records_parsed`
+- `variations_built` (total `Variation` objects created — reveals synthesis blowup)
+
+## Output
+
+Enabled by `--benchmark`. At the end of `main()`, print a formatted table to
+**stderr** (Nextflow captures stderr in `.command.err`, so it is visible in
+production runs too). Columns:
+
+| bucket | total time | % of run | calls | avg µs/call | calls/position |
+
+Rows sorted by total time descending. A header line reports total wall-clock and
+`positions_processed` so the per-position column is interpretable.
+
+The `calls/position` column is the key cross-scale signal: e.g. if
+`sql_get_indel_shift` shows 8 calls/position on 4 samples (~2 per sample per
+position), a 2000-sample run implies ~4000 SQL round-trips per coding locus —
+legible even though the local wall-clock is small.
+
+## Non-goals
+
+- No optimization / hotspot fix in this change (separate, evidence-backed change).
+- No new output artifacts, so the Nextflow process definition is untouched.
+- No new package dependencies (`time_ns` is in `Base`).
+
+## Testing
+
+- Zero-overhead-when-off is structural (macro expands to the bare expression);
+  confirmed by inspection.
+- Run `--benchmark` against the 4-sample local dataset inside the
+  `dnaseqanalysis` container and confirm the report prints with sane numbers and
+  the phase percentages sum to ~100%.
+- Existing Julia/Python test suites must still pass unchanged.

--- a/modules/mergeExperiments.nf
+++ b/modules/mergeExperiments.nf
@@ -102,7 +102,7 @@ process makeCodingData {
       --gtf_file $gtfFile \\
       --genome_fasta $genomeFastaFile \\
       --cds_db_out codingSequences.db \\
-      --indels_db_out codingIndels.db
+      --indels_db_out codingIndels.db ${params.benchmark ? '--benchmark' : ''}
     """
 
   stub:
@@ -191,7 +191,7 @@ process processSeqVars {
       --gtf_file $gtfFile \\
       --coverage_file $coverageFile \\
       --ploidy $params.ploidy \\
-      --output_vcf output.vcf ${params.benchmarkVariations ? '--benchmark' : ''}
+      --output_vcf output.vcf ${params.benchmark ? '--benchmark' : ''}
 
     mv snpFeature.dat variationFeature.dat
     bgzip output.vcf

--- a/modules/mergeExperiments.nf
+++ b/modules/mergeExperiments.nf
@@ -191,7 +191,7 @@ process processSeqVars {
       --gtf_file $gtfFile \\
       --coverage_file $coverageFile \\
       --ploidy $params.ploidy \\
-      --output_vcf output.vcf
+      --output_vcf output.vcf ${params.benchmarkVariations ? '--benchmark' : ''}
 
     mv snpFeature.dat variationFeature.dat
     bgzip output.vcf

--- a/nextflow.config
+++ b/nextflow.config
@@ -62,6 +62,7 @@ profiles {
       genomeFastaFile = "$launchDir/data/genome_haploid/genome.fasta"
       gtfFile         = "$launchDir/data/haploid_paired/Shared/pfal3D7.gtf"
       reference_strain = 'pfal3D7'
+      benchmarkVariations = false  // set true (or -profile ... --benchmarkVariations) to emit a timing/call-count report to .command.err
     }
 
    docker {

--- a/nextflow.config
+++ b/nextflow.config
@@ -62,7 +62,7 @@ profiles {
       genomeFastaFile = "$launchDir/data/genome_haploid/genome.fasta"
       gtfFile         = "$launchDir/data/haploid_paired/Shared/pfal3D7.gtf"
       reference_strain = 'pfal3D7'
-      benchmarkVariations = false  // set true (or -profile ... --benchmarkVariations) to emit a timing/call-count report to .command.err
+      benchmark = false  // set true (or add --benchmark on the run command) to emit timing/call-count reports for the merge Julia steps (makeCodingData, processSeqVars) to .command.err
     }
 
    docker {

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,3 +1,8 @@
+// Top-level defaults (always defined, regardless of -profile).
+params {
+  benchmark = false  // set true (or add --benchmark on the run command) to emit timing/call-count reports for the merge Julia steps (makeCodingData, processSeqVars) to .command.err
+}
+
 profiles {
 
   //--------------------------------------------------------------------------------------------
@@ -62,7 +67,6 @@ profiles {
       genomeFastaFile = "$launchDir/data/genome_haploid/genome.fasta"
       gtfFile         = "$launchDir/data/haploid_paired/Shared/pfal3D7.gtf"
       reference_strain = 'pfal3D7'
-      benchmark = false  // set true (or add --benchmark on the run command) to emit timing/call-count reports for the merge Julia steps (makeCodingData, processSeqVars) to .command.err
     }
 
    docker {

--- a/testing/t/genomicIndelIndex.jl
+++ b/testing/t/genomicIndelIndex.jl
@@ -1,0 +1,96 @@
+#!/usr/bin/env julia
+
+# Characterization tests for the in-memory GenomicIndelIndex in makeCodingData.jl,
+# which replaced two per-exon SQL queries (fasta_offset's SUM(shift) and
+# project_indels_to_cds's range scan) — the makeCodingData bottleneck. The
+# in-memory lookups MUST match the original SQL exactly; this builds a small
+# genomic_indels table, runs the original queries directly as the oracle, and
+# asserts agreement across many positions and exon ranges.
+#
+# Run with: julia testing/t/genomicIndelIndex.jl
+
+using Test
+using SQLite
+using SQLite.DBInterface: execute
+
+include(joinpath(@__DIR__, "../../bin/GtfUtils.jl"))
+include(joinpath(@__DIR__, "../../bin/makeCodingData.jl"))
+
+# --- oracles: the exact SQL the in-memory index replaced --------------------
+
+function sql_fasta_offset(db::SQLite.DB, strain::String, seq_id::String, before_pos::Int)
+    row = first(execute(db,
+        "SELECT COALESCE(SUM(shift), 0) FROM genomic_indels
+         WHERE strain = ? AND sequence_id = ? AND position < ?",
+        [strain, seq_id, before_pos]))
+    Int(row[1])
+end
+
+function sql_project_range(db::SQLite.DB, strain::String, seq_id::String, lo::Int, hi::Int)
+    [(Int(r[1]), Int(r[2])) for r in execute(db,
+        "SELECT position, shift FROM genomic_indels
+         WHERE strain = ? AND sequence_id = ? AND position >= ? AND position <= ?
+         ORDER BY position",
+        [strain, seq_id, lo, hi])]
+end
+
+function make_genomic_indel_db(rows::Vector)
+    db = SQLite.DB()
+    execute(db, """CREATE TABLE genomic_indels (
+        strain TEXT, sequence_id TEXT, position INTEGER, shift INTEGER)""")
+    for (strain, seq_id, pos, shift) in rows
+        execute(db, "INSERT INTO genomic_indels VALUES (?,?,?,?)", [strain, seq_id, pos, shift])
+    end
+    db
+end
+
+# Deliberately exercise: multiple sequences, out-of-order insertion, duplicate
+# positions (two events at the same position), positive & negative shifts, and a
+# second strain that must not leak into the first strain's index.
+const ROWS = [
+    ("strainA", "chr1", 100,  1),
+    ("strainA", "chr1", 50,   3),
+    ("strainA", "chr1", 100,  2),   # duplicate position
+    ("strainA", "chr1", 200, -1),
+    ("strainA", "chr2", 10,   6),
+    ("strainA", "chr2", 40,  -4),
+    ("strainB", "chr1", 75,  -3),   # different strain — must be isolated
+]
+
+@testset "fasta_offset matches SQL oracle at every position" begin
+    db  = make_genomic_indel_db(ROWS)
+    idx = load_strain_genomic_indels(db, "strainA")
+    for seq_id in ("chr1", "chr2", "chrX")   # chrX absent → always 0
+        for pos in 0:250
+            @test fasta_offset(idx, seq_id, pos) == sql_fasta_offset(db, "strainA", seq_id, pos)
+        end
+    end
+    close(db)
+end
+
+@testset "project range matches SQL oracle over many windows" begin
+    db  = make_genomic_indel_db(ROWS)
+    idx = load_strain_genomic_indels(db, "strainA")
+    positions, shifts = idx.byseq["chr1"][1], idx.byseq["chr1"][2]
+    for lo in 0:210, hi in lo:210
+        # replicate the in-memory slice the way project_indels_to_cds does
+        a = searchsortedfirst(positions, lo)
+        b = searchsortedlast(positions, hi)
+        mem = [(positions[i], shifts[i]) for i in a:b]
+        @test mem == sql_project_range(db, "strainA", "chr1", lo, hi)
+    end
+    close(db)
+end
+
+@testset "load isolates the requested strain" begin
+    db  = make_genomic_indel_db(ROWS)
+    idxB = load_strain_genomic_indels(db, "strainB")
+    # strainB has only chr1@75; strainA's chr1 rows must not appear
+    @test idxB.byseq["chr1"][1] == [75]
+    @test fasta_offset(idxB, "chr1", 100) == -3
+    @test fasta_offset(idxB, "chr1", 75)  == 0     # 75 not < 75
+    idxNone = load_strain_genomic_indels(db, "strainZ")
+    @test isempty(idxNone.byseq)
+    @test fasta_offset(idxNone, "chr1", 100) == 0
+    close(db)
+end

--- a/testing/t/indelShiftLookup.jl
+++ b/testing/t/indelShiftLookup.jl
@@ -1,0 +1,88 @@
+#!/usr/bin/env julia
+
+# Characterization tests for precompute_indel_shifts / lookup_indel_shift in
+# processSequenceVariations.jl. These replaced a per-variation SQL aggregate
+# (SUM(shift_amount) WHERE transcript_id=? AND strain=? AND position < ?) with a
+# precomputed prefix-sum + binary search. The lookup MUST match the old SQL
+# semantics exactly — this test builds a small indels table, runs the original
+# query directly, and asserts the in-memory lookup agrees at every position.
+#
+# Run with: julia testing/t/indelShiftLookup.jl
+
+using Test
+using SQLite
+using SQLite.DBInterface: execute
+
+include(joinpath(@__DIR__, "../../bin/processSequenceVariations.jl"))
+
+# The exact SQL the precompute replaced — kept here as the oracle.
+function sql_indel_shift(db::SQLite.DB, tid::String, strain::String, position::Int)
+    row = first(execute(db,
+        "SELECT COALESCE(SUM(shift_amount), 0) FROM indels WHERE transcript_id = ? AND strain = ? AND position < ?",
+        [tid, strain, position]))
+    row[1]::Int
+end
+
+function make_indels_db(rows::Vector)
+    db = SQLite.DB()
+    execute(db, """
+        CREATE TABLE indels (
+          strain        TEXT    NOT NULL,
+          transcript_id TEXT    NOT NULL,
+          position      INTEGER NOT NULL,
+          shift_amount  INTEGER NOT NULL
+        )
+    """)
+    for (strain, tid, pos, shift) in rows
+        execute(db, "INSERT INTO indels VALUES (?,?,?,?)", [strain, tid, pos, shift])
+    end
+    db
+end
+
+# Rows deliberately exercise: multiple strains & transcripts, out-of-order
+# insertion, duplicate positions (two events at the same position), and both
+# positive (insertion) and negative (deletion) shifts.
+const ROWS = [
+    ("strainA", "T1", 100,  1),
+    ("strainA", "T1", 50,   3),
+    ("strainA", "T1", 100,  2),   # duplicate position with T1@100 above
+    ("strainA", "T1", 200, -1),
+    ("strainA", "T2", 10,   6),
+    ("strainB", "T1", 75,  -3),
+    ("strainB", "T1", 300,  9),
+]
+
+@testset "lookup_indel_shift matches SQL oracle at every position" begin
+    db     = make_indels_db(ROWS)
+    shifts = precompute_indel_shifts(db)
+
+    # Every (strain, transcript) pair present, plus a pair with no indels.
+    pairs = [("strainA", "T1"), ("strainA", "T2"), ("strainB", "T1"),
+             ("strainA", "T3"), ("strainC", "T1")]
+
+    for (strain, tid) in pairs
+        for position in 0:350
+            expected = sql_indel_shift(db, tid, strain, position)
+            actual   = lookup_indel_shift(shifts, tid, strain, position)
+            @test actual == expected
+        end
+    end
+    close(db)
+end
+
+@testset "lookup_indel_shift specific values" begin
+    db     = make_indels_db(ROWS)
+    shifts = precompute_indel_shifts(db)
+
+    # strainA/T1 events: pos 50(+3), 100(+1), 100(+2), 200(-1)
+    @test lookup_indel_shift(shifts, "T1", "strainA", 50)  == 0    # nothing strictly before 50
+    @test lookup_indel_shift(shifts, "T1", "strainA", 51)  == 3    # only pos 50
+    @test lookup_indel_shift(shifts, "T1", "strainA", 100) == 3    # 100 not < 100
+    @test lookup_indel_shift(shifts, "T1", "strainA", 101) == 6    # 50 + both @100 (3+1+2)
+    @test lookup_indel_shift(shifts, "T1", "strainA", 999) == 5    # all: 3+1+2-1
+    @test lookup_indel_shift(shifts, "T1", "strainA", 0)   == 0
+
+    # Absent pair → 0
+    @test lookup_indel_shift(shifts, "T9", "strainZ", 100) == 0
+    close(db)
+end

--- a/testing/t/makeCodingData.jl
+++ b/testing/t/makeCodingData.jl
@@ -171,8 +171,9 @@ end
     strain_fasta = Dict("chr1" => "AAATGCCCCC")    # 2 bases deleted before pos 6
     exon = CdsExon("chr1", 6, 8, '+', "T1", 1)
     db = make_genomic_indel_db([("strainA", "chr1", 3, -2)])
-    @test extract_cds_sequence(ref_genome,   [exon])                        == "TGC"
-    @test extract_cds_sequence(strain_fasta, [exon], "strainA", db)         == "TGC"
+    idx = load_strain_genomic_indels(db, "strainA")
+    @test extract_cds_sequence(ref_genome,   [exon])              == "TGC"
+    @test extract_cds_sequence(strain_fasta, [exon], idx)         == "TGC"
 end
 
 @testset "extract_cds_sequence plus strand with upstream insertion in FASTA" begin
@@ -183,8 +184,9 @@ end
     strain_fasta = Dict("chr1" => "AAATTTCATGG")  # 3 bases inserted at pos 1
     exon = CdsExon("chr1", 4, 6, '+', "T1", 1)
     db = make_genomic_indel_db([("strainA", "chr1", 1, 3)])
-    @test extract_cds_sequence(ref_genome,   [exon])                == "CAT"
-    @test extract_cds_sequence(strain_fasta, [exon], "strainA", db) == "CAT"
+    idx = load_strain_genomic_indels(db, "strainA")
+    @test extract_cds_sequence(ref_genome,   [exon])      == "CAT"
+    @test extract_cds_sequence(strain_fasta, [exon], idx) == "CAT"
 end
 
 # ---------------------------------------------------------------------------
@@ -199,7 +201,7 @@ end
         ("strainA", "chr1", 50,  3),
     ])
     exon = CdsExon("chr1", 1, 100, '+', "T1", 1)
-    @test project_indels_to_cds(db, "strainA", [exon]) == [(9, -1), (49, 3)]
+    @test project_indels_to_cds(load_strain_genomic_indels(db, "strainA"), [exon]) == [(9, -1), (49, 3)]
 end
 
 @testset "project_indels_to_cds plus strand two exons" begin
@@ -211,7 +213,7 @@ end
     ])
     exon1 = CdsExon("chr1",  1, 10, '+', "T1", 1)
     exon2 = CdsExon("chr1", 20, 30, '+', "T1", 2)
-    @test project_indels_to_cds(db, "strainA", [exon1, exon2]) == [(4, -2), (15, 1)]
+    @test project_indels_to_cds(load_strain_genomic_indels(db, "strainA"), [exon1, exon2]) == [(4, -2), (15, 1)]
 end
 
 @testset "project_indels_to_cds minus strand single exon" begin
@@ -224,13 +226,13 @@ end
         ("strainA", "chr1", 8, -1),
     ])
     exon = CdsExon("chr1", 1, 10, '-', "T1", 1)
-    @test project_indels_to_cds(db, "strainA", [exon]) == [(2, -1), (7, 2)]
+    @test project_indels_to_cds(load_strain_genomic_indels(db, "strainA"), [exon]) == [(2, -1), (7, 2)]
 end
 
 @testset "project_indels_to_cds no indels for strain" begin
     db = make_genomic_indel_db([("strainA", "chr1", 5, -1)])
     exon = CdsExon("chr1", 1, 10, '+', "T1", 1)
-    @test isempty(project_indels_to_cds(db, "strainB", [exon]))
+    @test isempty(project_indels_to_cds(load_strain_genomic_indels(db, "strainB"), [exon]))
 end
 
 @testset "project_indels_to_cds indels outside exon boundaries excluded" begin
@@ -240,7 +242,7 @@ end
         ("strainA", "chr1", 11, -1),   # after exon
     ])
     exon = CdsExon("chr1", 1, 10, '+', "T1", 1)
-    result = project_indels_to_cds(db, "strainA", [exon])
+    result = project_indels_to_cds(load_strain_genomic_indels(db, "strainA"), [exon])
     @test length(result) == 1
     @test result[1] == (4, -1)
 end


### PR DESCRIPTION
## Summary

The `mergeExperiments` workflow took ~14 h for 200 samples, with most time in the two Julia steps. This PR adds benchmarking to locate the cost, then eliminates the SQL-round-trip hotspots each step exposed. Behavior is unchanged — outputs are byte-identical; only speed changes.

On a 20-sample test dataset the two merge steps went from ~53 min combined to ~64 s, and the **full workflow now finishes in ~2 min** end-to-end.

## What's here

**Instrumentation** (`bin/Benchmark.jl`, shared by both scripts)
- `--benchmark` flag → per-phase timers + call counters → report on stderr (`.command.err`).
- Zero overhead when off (`@bench` expands to the bare expression).
- The `calls/pos` / `calls/strain` column exposes O(samples)/O(strains) scaling even on tiny local data.
- Nextflow param `benchmark` (top-level default) threads `--benchmark` into both merge processes.

**processSeqVars fixes** — was ~95% SQLite
- Index `coding_sequences(transcript_id)` at build time (`makeCodingData.jl`): the PK leads with `strain`, so a `transcript_id`-only lookup full-scanned the 364 MB table (231 ms/call).
- Precompute cumulative indel shifts once (`precompute_indel_shifts` + binary-search `lookup_indel_shift`), removing ~778k per-variation `get_indel_shift` queries.
- **Result: 1661.84 s → 52.30 s (~32×)** on 20 samples; `sql_load_transcript` 931 s → 2 s, `sql_get_indel_shift` eliminated.

**makeCodingData fix** — was ~99% SQLite
- `GenomicIndelIndex` loads each strain's genomic indels in one query into per-sequence sorted arrays + prefix-sums; `fasta_offset` and `project_indels_to_cds` become binary-search lookups. ~988k queries → 24 (one per strain).
- **Result: 1498 s → 11.5 s (~130×)** on 20 samples.

## Verification

- Characterization tests (`testing/t/indelShiftLookup.jl`, `testing/t/genomicIndelIndex.jl`) prove the in-memory lookups equal the original SQL across every position/window (duplicates, multiple sequences, strain isolation). Existing tests updated to new signatures.
- Full Julia suite passes.
- Re-ran both steps on the 20-sample inputs: all outputs (`.dat`, `output.vcf`, HSSS binaries) and DB table contents **byte-identical** to a prior run.
- Full `mergeExperiments` workflow run end-to-end through Nextflow: ~2 min.

Design + findings: `docs/superpowers/specs/2026-07-16-benchmark-processSequenceVariations-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)